### PR TITLE
#399 Item 3: More branch spacing

### DIFF
--- a/src/components/side-panel/style-side-panel/layout-section.tsx
+++ b/src/components/side-panel/style-side-panel/layout-section.tsx
@@ -6,6 +6,7 @@ import { useRootSelector } from '../../../redux';
 import { canvasConfig, RmgStyle } from '../../../constants/constants';
 import {
     setBranchSpacing,
+    setBranchSpacingPct,
     setDirectionIndicatorX,
     setDirectionIndicatorY,
     setPaddingPercentage,
@@ -25,6 +26,7 @@ export default function LayoutSection() {
         svg_height,
         y_pc,
         branch_spacing,
+        branchSpacingPct,
         padding,
         direction_gz_x,
         direction_gz_y,
@@ -60,6 +62,16 @@ export default function LayoutSection() {
             min: 0,
             max: 100,
             onChange: val => dispatch(setBranchSpacing(val)),
+            hidden: ![RmgStyle.SHMetro].includes(rmgStyle),
+        },
+        {
+            type: 'slider',
+            label: !loop ? t('Branch spacing') : t('StyleSidePanel.layout.branchSpacingLoop'),
+            value: branchSpacingPct,
+            min: 0,
+            max: 100,
+            onChange: val => dispatch(setBranchSpacingPct(val)),
+            hidden: ![RmgStyle.MTR, RmgStyle.GZMTR].includes(rmgStyle),
         },
         {
             type: 'slider',

--- a/src/components/side-panel/style-side-panel/layout-section.tsx
+++ b/src/components/side-panel/style-side-panel/layout-section.tsx
@@ -5,7 +5,6 @@ import { useDispatch } from 'react-redux';
 import { useRootSelector } from '../../../redux';
 import { canvasConfig, RmgStyle } from '../../../constants/constants';
 import {
-    setBranchSpacing,
     setBranchSpacingPct,
     setDirectionIndicatorX,
     setDirectionIndicatorY,
@@ -25,7 +24,6 @@ export default function LayoutSection() {
         svgWidth,
         svg_height,
         y_pc,
-        branch_spacing,
         branchSpacingPct,
         padding,
         direction_gz_x,
@@ -57,21 +55,11 @@ export default function LayoutSection() {
         },
         {
             type: 'slider',
-            label: !loop ? t('StyleSidePanel.layout.branchSpacing') : t('StyleSidePanel.layout.branchSpacingLoop'),
-            value: branch_spacing,
-            min: 0,
-            max: 100,
-            onChange: val => dispatch(setBranchSpacing(val)),
-            hidden: ![RmgStyle.SHMetro].includes(rmgStyle),
-        },
-        {
-            type: 'slider',
             label: !loop ? t('Branch spacing') : t('StyleSidePanel.layout.branchSpacingLoop'),
             value: branchSpacingPct,
             min: 0,
-            max: 100,
+            max: loop ? 50 : 100,
             onChange: val => dispatch(setBranchSpacingPct(val)),
-            hidden: ![RmgStyle.MTR, RmgStyle.GZMTR].includes(rmgStyle),
         },
         {
             type: 'slider',

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -217,6 +217,8 @@ export interface RMGParam {
      * Branch spacing (in pixels) of line.
      */
     branch_spacing: number;
+    // Branch spacing percentage (space between upper and lower branch)
+    branchSpacingPct: number;
     direction: ShortDirection;
     /**
      * Platform number of the destination canvas. Set to '' will hide the element.

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -213,11 +213,9 @@ export interface RMGParam {
      * Left and right margin of line (in percentage).
      */
     padding: number;
-    /**
-     * Branch spacing (in pixels) of line.
+    /** Branch spacing percentage (space between upper and lower branch).
+     *  In SHMetro loop line, this is also used in determining vertical padding.
      */
-    branch_spacing: number;
-    // Branch spacing percentage (space between upper and lower branch)
     branchSpacingPct: number;
     direction: ShortDirection;
     /**

--- a/src/i18n/translations/zh-Hans.json
+++ b/src/i18n/translations/zh-Hans.json
@@ -269,6 +269,7 @@
 
     "Branch on the left": "左侧支线",
     "Branch on the right": "右侧支线",
+    "Branch spacing": "支线间距",
     "Branches": "支线",
     "Canvas scale": "画面缩放级别",
     "Canvas to show": "显示的画面",

--- a/src/i18n/translations/zh-Hant.json
+++ b/src/i18n/translations/zh-Hant.json
@@ -268,6 +268,7 @@
 
     "Branch on the left": "左側支綫",
     "Branch on the right": "右側支綫",
+    "Branch spacing": "支綫間距",
     "Branches": "支綫",
     "Canvas scale": "畫面縮放比例",
     "Canvas to show": "顯示的畫面",

--- a/src/redux/param/action.ts
+++ b/src/redux/param/action.ts
@@ -30,6 +30,7 @@ export const SET_SVG_HEIGHT = 'SET_SVG_HEIGHT';
 export const SET_SVG_WIDTH = 'SET_SVG_WIDTH';
 export const SET_Y_PERCENTAGE = 'SET_Y_PERCENTAGE';
 export const SET_BRANCH_SPACING = 'SET_BRANCH_SPACING';
+export const SET_BRANCH_SPACING_PCT = 'SET_BRANCH_SPACING_PCT';
 export const SET_PADDING_PERCENTAGE = 'SET_PADDING_PERCENTAGE';
 export const SET_DIRECTION_INDICATOR_X = 'SET_DIRECTION_INDICATOR_X';
 export const SET_DIRECTION_INDICATOR_Y = 'SET_DIRECTION_INDICATOR_Y';
@@ -85,6 +86,11 @@ export interface setYPercentageAction {
 export interface setBranchSpacingAction {
     type: typeof SET_BRANCH_SPACING;
     branchSpacing: number;
+}
+
+export interface setBranchSpacingPctAction {
+    type: typeof SET_BRANCH_SPACING_PCT;
+    branchSpacingPct: number;
 }
 
 export interface setPaddingPercentageAction {
@@ -213,6 +219,10 @@ export const setYPercentage = (yPercentage: number): setYPercentageAction => {
 
 export const setBranchSpacing = (branchSpacing: number): setBranchSpacingAction => {
     return { type: SET_BRANCH_SPACING, branchSpacing };
+};
+
+export const setBranchSpacingPct = (branchSpacingPct: number): setBranchSpacingPctAction => {
+    return { type: SET_BRANCH_SPACING_PCT, branchSpacingPct };
 };
 
 export const setPaddingPercentage = (paddingPercentage: number): setPaddingPercentageAction => {

--- a/src/redux/param/action.ts
+++ b/src/redux/param/action.ts
@@ -29,7 +29,6 @@ export const SET_STYLE = 'SET_STYLE';
 export const SET_SVG_HEIGHT = 'SET_SVG_HEIGHT';
 export const SET_SVG_WIDTH = 'SET_SVG_WIDTH';
 export const SET_Y_PERCENTAGE = 'SET_Y_PERCENTAGE';
-export const SET_BRANCH_SPACING = 'SET_BRANCH_SPACING';
 export const SET_BRANCH_SPACING_PCT = 'SET_BRANCH_SPACING_PCT';
 export const SET_PADDING_PERCENTAGE = 'SET_PADDING_PERCENTAGE';
 export const SET_DIRECTION_INDICATOR_X = 'SET_DIRECTION_INDICATOR_X';
@@ -81,11 +80,6 @@ export interface setSvgWidthAction {
 export interface setYPercentageAction {
     type: typeof SET_Y_PERCENTAGE;
     yPercentage: number;
-}
-
-export interface setBranchSpacingAction {
-    type: typeof SET_BRANCH_SPACING;
-    branchSpacing: number;
 }
 
 export interface setBranchSpacingPctAction {
@@ -215,10 +209,6 @@ export const setStyle = (style: RmgStyle): setStyleAction => {
 
 export const setYPercentage = (yPercentage: number): setYPercentageAction => {
     return { type: SET_Y_PERCENTAGE, yPercentage };
-};
-
-export const setBranchSpacing = (branchSpacing: number): setBranchSpacingAction => {
-    return { type: SET_BRANCH_SPACING, branchSpacing };
 };
 
 export const setBranchSpacingPct = (branchSpacingPct: number): setBranchSpacingPctAction => {

--- a/src/redux/param/reducer.ts
+++ b/src/redux/param/reducer.ts
@@ -1,7 +1,9 @@
 import { CityCode } from '@railmapgen/rmg-palette-resources';
-import { MonoColour, PanelTypeGZMTR, RMGParam, ShortDirection, RmgStyle } from '../../constants/constants';
+import { MonoColour, PanelTypeGZMTR, RMGParam, RmgStyle, ShortDirection } from '../../constants/constants';
 import {
     SET_BRANCH_SPACING,
+    SET_BRANCH_SPACING_PCT,
+    SET_COLINE_BULK,
     SET_CURRENT_STATION,
     SET_CUSTOMISED_MTR_DESTINATION,
     SET_DIRECTION,
@@ -10,6 +12,8 @@ import {
     SET_FULL_PARAM,
     SET_LINE_NAME,
     SET_LINE_NUM,
+    SET_LOOP,
+    SET_LOOP_INFO,
     SET_NAME_POSITION,
     SET_NOTES,
     SET_PADDING_PERCENTAGE,
@@ -18,15 +22,14 @@ import {
     SET_PSD_NUM,
     SET_STATION,
     SET_STATIONS_BULK,
+    SET_STYLE,
     SET_SVG_HEIGHT,
     SET_SVG_WIDTH,
     SET_THEME,
     SET_Y_PERCENTAGE,
-    SET_STYLE,
-    SET_COLINE_BULK,
-    SET_LOOP,
-    SET_LOOP_INFO,
     setBranchSpacingAction,
+    setBranchSpacingPctAction,
+    setColineBulkAction,
     setCurrentStationAction,
     setCustomisedMtrDestinationAction,
     setDirectionAction,
@@ -35,6 +38,8 @@ import {
     setFullParamAction,
     setLineNameAction,
     setLineNumAction,
+    setLoopAction,
+    setLoopInfoAction,
     setNamePositionAction,
     setNotesAction,
     setPaddingPercentageAction,
@@ -43,14 +48,11 @@ import {
     setPsdNumAction,
     setStationAction,
     setStationsBulkAction,
+    setStyleAction,
     setSvgHeightAction,
     setSvgWidthAction,
     setThemeAction,
     setYPercentageAction,
-    setStyleAction,
-    setColineBulkAction,
-    setLoopAction,
-    setLoopInfoAction,
 } from './action';
 
 const initialState: RMGParam = {
@@ -65,6 +67,7 @@ const initialState: RMGParam = {
     y_pc: 50,
     padding: 10,
     branch_spacing: 10,
+    branchSpacingPct: 10,
     direction: ShortDirection.left,
     platform_num: '1',
     theme: [CityCode.Hongkong, 'twl', '#E2231A', MonoColour.white],
@@ -103,6 +106,7 @@ export default function ParamReducer(
         | setSvgWidthAction
         | setYPercentageAction
         | setBranchSpacingAction
+        | setBranchSpacingPctAction
         | setPaddingPercentageAction
         | setDirectionIndicatorXAction
         | setDirectionIndicatorYAction
@@ -136,6 +140,8 @@ export default function ParamReducer(
             return { ...state, y_pc: action.yPercentage };
         case SET_BRANCH_SPACING:
             return { ...state, branch_spacing: action.branchSpacing };
+        case SET_BRANCH_SPACING_PCT:
+            return { ...state, branchSpacingPct: action.branchSpacingPct };
         case SET_PADDING_PERCENTAGE:
             return { ...state, padding: action.paddingPercentage };
         case SET_DIRECTION_INDICATOR_X:

--- a/src/redux/param/reducer.ts
+++ b/src/redux/param/reducer.ts
@@ -1,7 +1,6 @@
 import { CityCode } from '@railmapgen/rmg-palette-resources';
 import { MonoColour, PanelTypeGZMTR, RMGParam, RmgStyle, ShortDirection } from '../../constants/constants';
 import {
-    SET_BRANCH_SPACING,
     SET_BRANCH_SPACING_PCT,
     SET_COLINE_BULK,
     SET_CURRENT_STATION,
@@ -27,7 +26,6 @@ import {
     SET_SVG_WIDTH,
     SET_THEME,
     SET_Y_PERCENTAGE,
-    setBranchSpacingAction,
     setBranchSpacingPctAction,
     setColineBulkAction,
     setCurrentStationAction,
@@ -66,7 +64,6 @@ const initialState: RMGParam = {
     style: RmgStyle.MTR,
     y_pc: 50,
     padding: 10,
-    branch_spacing: 10,
     branchSpacingPct: 10,
     direction: ShortDirection.left,
     platform_num: '1',
@@ -105,7 +102,6 @@ export default function ParamReducer(
         | setSvgHeightAction
         | setSvgWidthAction
         | setYPercentageAction
-        | setBranchSpacingAction
         | setBranchSpacingPctAction
         | setPaddingPercentageAction
         | setDirectionIndicatorXAction
@@ -138,8 +134,6 @@ export default function ParamReducer(
             return { ...state, svgWidth: { ...state.svgWidth, [action.canvas]: action.svgWidth } };
         case SET_Y_PERCENTAGE:
             return { ...state, y_pc: action.yPercentage };
-        case SET_BRANCH_SPACING:
-            return { ...state, branch_spacing: action.branchSpacing };
         case SET_BRANCH_SPACING_PCT:
             return { ...state, branchSpacingPct: action.branchSpacingPct };
         case SET_PADDING_PERCENTAGE:

--- a/src/redux/param/util.ts
+++ b/src/redux/param/util.ts
@@ -98,6 +98,7 @@ export const initParam = (style: RmgStyle, language: LanguageCode): RMGParam => 
         y_pc: 50,
         padding: 10,
         branch_spacing: 10,
+        branchSpacingPct: 33,
         direction: ShortDirection.left,
         platform_num: '1',
         theme: initTheme(style),

--- a/src/redux/param/util.ts
+++ b/src/redux/param/util.ts
@@ -97,7 +97,6 @@ export const initParam = (style: RmgStyle, language: LanguageCode): RMGParam => 
         style: style,
         y_pc: 50,
         padding: 10,
-        branch_spacing: 10,
         branchSpacingPct: 33,
         direction: ShortDirection.left,
         platform_num: '1',

--- a/src/svgs/indoor/indoor-shmetro.tsx
+++ b/src/svgs/indoor/indoor-shmetro.tsx
@@ -93,7 +93,7 @@ const IndoorSHMetro = () => {
         [deps]
     );
     const ys = Object.keys(yShares).reduce(
-        (acc, cur) => ({ ...acc, [cur]: yShares[cur] * param.branch_spacing * 2 }),
+        (acc, cur) => ({ ...acc, [cur]: (yShares[cur] * param.branchSpacingPct * param.svg_height) / 150 }),
         {} as typeof yShares
     );
 
@@ -125,7 +125,7 @@ const IndoorSHMetro = () => {
         lineXs,
         xs,
         ys,
-        param.branch_spacing * 2,
+        (param.branchSpacingPct * param.svg_height) / 150,
         criticalPath,
         0
     );

--- a/src/svgs/indoor/indoor-shmetro.tsx
+++ b/src/svgs/indoor/indoor-shmetro.tsx
@@ -93,7 +93,7 @@ const IndoorSHMetro = () => {
         [deps]
     );
     const ys = Object.keys(yShares).reduce(
-        (acc, cur) => ({ ...acc, [cur]: (yShares[cur] * param.branchSpacingPct * param.svg_height) / 150 }),
+        (acc, cur) => ({ ...acc, [cur]: (yShares[cur] * param.branchSpacingPct * param.svg_height) / 200 }),
         {} as typeof yShares
     );
 
@@ -125,7 +125,7 @@ const IndoorSHMetro = () => {
         lineXs,
         xs,
         ys,
-        (param.branchSpacingPct * param.svg_height) / 150,
+        (param.branchSpacingPct * param.svg_height) / 200,
         criticalPath,
         0
     );

--- a/src/svgs/railmap/main/coline/coline-shmetro.tsx
+++ b/src/svgs/railmap/main/coline/coline-shmetro.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { drawLine } from '../../methods/share';
-import { calculateColineStations, calculateColine } from '../../methods/shmetro-coline';
-import { AtLeastOneOfPartial, Services, InterchangeInfo } from '../../../../constants/constants';
+import { calculateColine, calculateColineStations } from '../../methods/shmetro-coline';
+import { AtLeastOneOfPartial, InterchangeInfo, Services } from '../../../../constants/constants';
 import { useRootSelector } from '../../../../redux';
 import { _linePath, StationGroupProps } from '../main-shmetro';
 import StationSHMetro from '../station/station-shmetro';
@@ -31,10 +31,11 @@ export const ColineSHMetro = (props: Props) => {
     const { xs, servicesPresent, stnStates } = props;
 
     const {
+        svg_height,
         direction,
         stn_list,
         current_stn_idx,
-        branch_spacing,
+        branchSpacingPct,
         info_panel_type,
         coline: colineInfo,
     } = useRootSelector(store => store.param);
@@ -60,7 +61,7 @@ export const ColineSHMetro = (props: Props) => {
         .filter(([k, v]) => v <= 0)
         .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {} as typeof yShares);
     const colineYs = Object.keys(colineYShares).reduce(
-        (acc, cur) => ({ ...acc, [cur]: -colineYShares[cur] * branch_spacing }),
+        (acc, cur) => ({ ...acc, [cur]: (-colineYShares[cur] * branchSpacingPct * svg_height) / 300 }),
         {} as typeof yShares
     );
 

--- a/src/svgs/railmap/main/loop/loop-shmetro.tsx
+++ b/src/svgs/railmap/main/loop/loop-shmetro.tsx
@@ -5,11 +5,11 @@ import { CanvasType, Services, ShortDirection } from '../../../../constants/cons
 import { useRootSelector } from '../../../../redux';
 import { isColineBranch } from '../../../../redux/param/coline-action';
 import {
+    get_xshares_yshares_of_loop,
+    LoopStns,
     split_loop_stns,
     split_loop_stns_with_branch,
     split_loop_stns_with_branches,
-    LoopStns,
-    get_xshares_yshares_of_loop,
 } from '../../methods/shmetro-loop';
 import { get_loop_branches, LoopBranches } from './loop-branches-shmetro';
 import { LoopColine } from './loop-coline-shmetro';
@@ -22,7 +22,7 @@ const LoopSHMetro = (props: { bank_angle: boolean; canvas: CanvasType.RailMap | 
         svgWidth: svg_width,
         svg_height,
         padding,
-        branch_spacing,
+        branchSpacingPct,
         direction,
         info_panel_type,
         stn_list,
@@ -83,9 +83,11 @@ const LoopSHMetro = (props: { bank_angle: boolean; canvas: CanvasType.RailMap | 
 
     // all y_shares in branches will be 0
     const y_shares = { ...y_shares_loop, ...Object.fromEntries(loop_branches.flat().map(stn => [stn, 0])) };
+    // before: branch_spacing / 400 * svg_height (Chito)
+    const verticalPadding = ((branchSpacingPct * svg_height) / 300 / 400) * svg_height;
     const line_ys = [
-        225 + (branch_spacing / 400) * svg_height,
-        svg_height - 75 - (canvas === CanvasType.RailMap ? 0 : 125) - (branch_spacing / 400) * svg_height,
+        225 + verticalPadding,
+        svg_height - 75 - (canvas === CanvasType.RailMap ? 0 : 125) - verticalPadding,
     ] as [number, number];
     const ys = Object.keys(y_shares).reduce(
         (acc, cur) => ({

--- a/src/svgs/railmap/main/loop/loop-shmetro.tsx
+++ b/src/svgs/railmap/main/loop/loop-shmetro.tsx
@@ -84,7 +84,7 @@ const LoopSHMetro = (props: { bank_angle: boolean; canvas: CanvasType.RailMap | 
     // all y_shares in branches will be 0
     const y_shares = { ...y_shares_loop, ...Object.fromEntries(loop_branches.flat().map(stn => [stn, 0])) };
     // before: branch_spacing / 400 * svg_height (Chito)
-    const verticalPadding = ((branchSpacingPct * svg_height) / 300 / 400) * svg_height;
+    const verticalPadding = (branchSpacingPct * svg_height) / 300;
     const line_ys = [
         225 + verticalPadding,
         svg_height - 75 - (canvas === CanvasType.RailMap ? 0 : 125) - verticalPadding,

--- a/src/svgs/railmap/main/main-gzmtr.tsx
+++ b/src/svgs/railmap/main/main-gzmtr.tsx
@@ -75,14 +75,17 @@ const getXShare = (stnId: string, adjMat: ReturnType<typeof adjacencyList>, bran
 const MainGZMTR = () => {
     const { branches, routes, depsStr: deps } = useRootSelector(store => store.helper);
 
-    const svgWidths = useRootSelector(store => store.param.svgWidth);
-    const yPercentage = useRootSelector(store => store.param.y_pc);
-    const paddingPercentage = useRootSelector(store => store.param.padding);
-    const branchSpacing = useRootSelector(store => store.param.branch_spacing);
-    const direction = useRootSelector(store => store.param.direction);
-    const lineName = useRootSelector(store => store.param.line_name);
-    const currentStationIndex = useRootSelector(store => store.param.current_stn_idx);
-    const stationList = useRootSelector(store => store.param.stn_list);
+    const {
+        svgWidth: svgWidths,
+        svg_height: svgH,
+        y_pc: yPercentage,
+        padding: paddingPercentage,
+        branchSpacingPct,
+        direction,
+        line_name: lineName,
+        current_stn_idx: currentStationIndex,
+        stn_list: stationList,
+    } = useRootSelector(store => store.param);
 
     const adjMat = adjacencyList(stationList, wideFactor, wideFactor);
 
@@ -132,7 +135,7 @@ const MainGZMTR = () => {
         [deps]
     );
     const ys = Object.keys(yShares).reduce(
-        (acc, cur) => ({ ...acc, [cur]: -yShares[cur] * branchSpacing }),
+        (acc, cur) => ({ ...acc, [cur]: (-yShares[cur] * branchSpacingPct * svgH) / 200 }),
         {} as typeof yShares
     );
 

--- a/src/svgs/railmap/main/main-mtr.tsx
+++ b/src/svgs/railmap/main/main-mtr.tsx
@@ -21,15 +21,17 @@ const getNamePos = (stnId: string, branches: string[][], { isStagger, isFlip }: 
 const MainMTR = () => {
     const { branches, routes, depsStr: deps } = useRootSelector(store => store.helper);
 
-    const svgWidths = useRootSelector(store => store.param.svgWidth);
-    const yPercentage = useRootSelector(store => store.param.y_pc);
-    const paddingPercentage = useRootSelector(store => store.param.padding);
-    const branchSpacing = useRootSelector(store => store.param.branch_spacing);
-    const direction = useRootSelector(store => store.param.direction);
-    const namePosition = useRootSelector(store => store.param.namePosMTR);
-
-    const currentStationIndex = useRootSelector(store => store.param.current_stn_idx);
-    const stationList = useRootSelector(store => store.param.stn_list);
+    const {
+        svgWidth: svgWidths,
+        svg_height: svgH,
+        y_pc: yPercentage,
+        padding: paddingPercentage,
+        branchSpacingPct,
+        direction,
+        namePosMTR: namePosition,
+        current_stn_idx: currentStationIndex,
+        stn_list: stationList,
+    } = useRootSelector(store => store.param);
 
     const adjMat = adjacencyList(stationList, leftWideFactor, rightWideFactor);
 
@@ -69,11 +71,11 @@ const MainMTR = () => {
             Object.keys(stationList).reduce<Record<string, number>>(
                 (acc, cur) => ({
                     ...acc,
-                    [cur]: getStationYShare(cur, branches, stationList) * branchSpacing,
+                    [cur]: (getStationYShare(cur, branches, stationList) * branchSpacingPct * svgH) / 200,
                 }),
                 {}
             ),
-        [deps, branchSpacing]
+        [deps, branchSpacingPct, svgH]
     );
 
     const stnStates = useMemo(
@@ -94,7 +96,7 @@ const MainMTR = () => {
         lineXs,
         xs,
         ys,
-        branchSpacing,
+        (branchSpacingPct * svgH) / 200,
         criticalPath
     );
 

--- a/src/svgs/railmap/main/main-shmetro.tsx
+++ b/src/svgs/railmap/main/main-shmetro.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { adjacencyList, getXShareMTR, criticalPathMethod, drawLine, getStnState } from '../methods/share';
+import { adjacencyList, criticalPathMethod, drawLine, getStnState, getXShareMTR } from '../methods/share';
 import StationSHMetro from './station/station-shmetro';
 import ColineSHMetro from './coline/coline-shmetro';
 import { AtLeastOneOfPartial, Services, StationDict } from '../../../constants/constants';
@@ -16,7 +16,7 @@ type Paths = AtLeastOneOfPartial<Record<Services, servicesPath>>;
 const MainSHMetro = () => {
     const { routes, branches, depsStr: deps } = useRootSelector(store => store.helper);
     const param = useRootSelector(store => store.param);
-    const { stn_list, branch_spacing, coline, direction } = useRootSelector(store => store.param);
+    const { svg_height, stn_list, branchSpacingPct, coline, direction } = useRootSelector(store => store.param);
 
     const adjMat = adjacencyList(
         param.stn_list,
@@ -79,7 +79,7 @@ const MainSHMetro = () => {
         .filter(([k, v]) => v >= 0)
         .reduce((acc, [k, v]) => ({ ...acc, [k]: v }), {} as typeof yShares);
     const lineYs = Object.keys(lineYShares).reduce(
-        (acc, cur) => ({ ...acc, [cur]: -lineYShares[cur] * branch_spacing }),
+        (acc, cur) => ({ ...acc, [cur]: (-lineYShares[cur] * branchSpacingPct * svg_height) / 300 }),
         {} as typeof yShares
     );
 

--- a/src/svgs/railmap/methods/share.ts
+++ b/src/svgs/railmap/methods/share.ts
@@ -93,17 +93,6 @@ export const getXShareMTR = (stnId: string, adjMat: ReturnType<typeof adjacencyL
     }
 };
 
-const getYShare = (stnId: string, stnList: { [stnId: string]: StationInfo }) => {
-    return Global.getYShareMTR(stnId, stnList);
-};
-
-/**
- * Vertical position (in pixels) of station icon related to vertical position of line.
- */
-export const getYReal = (stnId: string, param: RMGParam) => {
-    return -getYShare(stnId, param.stn_list) * param.branch_spacing;
-};
-
 const _isPredecessor = (stnId1: string, stnId2: string, routes: string[][]) => {
     for (let route of routes) {
         let idx1 = route.indexOf(stnId1);

--- a/src/svgs/railmap/methods/share.ts
+++ b/src/svgs/railmap/methods/share.ts
@@ -1,5 +1,4 @@
-import * as Global from '../../../methods';
-import { RMGParam, ShortDirection, StationDict, StationInfo } from '../../../constants/constants';
+import { ShortDirection, StationDict, StationInfo } from '../../../constants/constants';
 
 /**
  * Compute the adjacency list of the graph.
@@ -159,16 +158,6 @@ export class Stations {
      */
     protected rightWideFactor = (stnId: string) => {
         return 0;
-    };
-
-    /**
-     * Path weight from station 1 to station 2 (station 2 must be a child of station 1, otherwise return `-Infinity`).
-     */
-    public pathWeight = (stnId1: string, stnId2: string) => {
-        if (!this.stnList[stnId1].children.includes(stnId2)) {
-            return -Infinity;
-        }
-        return 1 + this.rightWideFactor(stnId1) + this.leftWideFactor(stnId2);
     };
 
     protected getYShare(stnId: string, branches?: string[][]): number {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -249,7 +249,7 @@ export const updateParam = (param: { [x: string]: any }) => {
         s.int_padding = s.int_padding ?? (param.loop ? 250 : 355);
     });
 
-    // Version 5.4.13
+    // Version 5.4.19
     if (param.branchSpacingPct === undefined) {
         if (param.style === RmgStyle.SHMetro) {
             param.branchSpacingPct = Math.round((param.branch_spacing / param.svg_height) * 300);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -256,6 +256,8 @@ export const updateParam = (param: { [x: string]: any }) => {
         } else {
             param.branchSpacingPct = Math.round((param.branch_spacing / param.svg_height) * 200);
         }
+
+        delete param.branch_spacing;
     }
 
     return param;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -249,6 +249,15 @@ export const updateParam = (param: { [x: string]: any }) => {
         s.int_padding = s.int_padding ?? (param.loop ? 250 : 355);
     });
 
+    // Version 5.4.13
+    if (param.branchSpacingPct === undefined) {
+        if (param.style === RmgStyle.SHMetro) {
+            param.branchSpacingPct = Math.round((param.branch_spacing / param.svg_height) * 300);
+        } else {
+            param.branchSpacingPct = Math.round((param.branch_spacing / param.svg_height) * 200);
+        }
+    }
+
     return param;
 };
 


### PR DESCRIPTION
In this change, `branch_spacing` (bs) field in `param` is replaced `branchSpacingPct` (bsp) with the below conversion:

$$bsp_{sh} = \frac{bs}{svgH} \times 300 \Leftrightarrow bs = \frac{bsp_{sh} \times svgH}{300}$$

$$bsp_{others} = \frac{bs}{svgH} \times 200 \Leftrightarrow bs = \frac{bsp_{others} \times svgH}{200}$$

The generic meaning of `branchSpacingPct` is the distance between upper and lower branches, divided by the height of the canvas.

@thekingofcity Please help to review the changes to SHMetro related SVG components. 