### PR TITLE
#40 Replace single paramRegistry with multiple paramConfig

### DIFF
--- a/src/components/param-selector-view/index.test.tsx
+++ b/src/components/param-selector-view/index.test.tsx
@@ -4,7 +4,6 @@ import ParamSelectorView from './index';
 import rootReducer from '../../redux';
 import { createMockAppStore, createParamInLocalStorage } from '../../setupTests';
 import { fireEvent, screen } from '@testing-library/react';
-import { getParamRegistry } from '../../util/param-manager-utils';
 
 const realStore = rootReducer.getState();
 
@@ -12,8 +11,7 @@ describe('ParamSelectorView', () => {
     it('Can disable open button if no project is selected', () => {
         createParamInLocalStorage('test-1');
         createParamInLocalStorage('test-2');
-        const paramRegistry = getParamRegistry();
-        const mockStore = createMockAppStore({ ...realStore, app: { ...realStore.app, paramRegistry } });
+        const mockStore = createMockAppStore({ ...realStore, app: { ...realStore.app } });
 
         render(<ParamSelectorView />, { store: mockStore, route: '/' });
 

--- a/src/components/param-selector-view/index.tsx
+++ b/src/components/param-selector-view/index.tsx
@@ -7,8 +7,6 @@ import { MdAdd, MdOpenInBrowser } from 'react-icons/md';
 import { nanoid } from 'nanoid';
 import rmgRuntime from '@railmapgen/rmg-runtime';
 import { Events, LocalStorageKey } from '../../constants/constants';
-import { useRootDispatch } from '../../redux';
-import { removeParam } from '../../redux/app/app-slice';
 import ParamSelector from '../param-selector-view/param-selector';
 
 const paramSelectorCardStyle: SystemStyleObject = {
@@ -39,7 +37,6 @@ export default function ParamSelectorView() {
     const [searchParams, setSearchParams] = useSearchParams();
     const urlParamId = searchParams.get('project');
 
-    const dispatch = useRootDispatch();
     const [selectedParam, setSelectedParam] = useState<string>();
     const selectorRef = useRef<HTMLDivElement>(null);
 
@@ -59,8 +56,8 @@ export default function ParamSelectorView() {
 
     const handleDelete = (id: string) => {
         setSelectedParam(undefined);
-        dispatch(removeParam(id));
         window.localStorage.removeItem(LocalStorageKey.PARAM_BY_ID + id);
+        window.localStorage.removeItem(LocalStorageKey.PARAM_CONFIG_BY_ID + id);
         rmgRuntime.event(Events.REMOVE_PARAM, {});
     };
 

--- a/src/components/param-selector-view/param-selector.test.tsx
+++ b/src/components/param-selector-view/param-selector.test.tsx
@@ -2,22 +2,13 @@ import React from 'react';
 import rootReducer from '../../redux';
 import { render } from '../../test-utils';
 import ParamSelector from './param-selector';
-import { createMockAppStore } from '../../setupTests';
+import { createMockAppStore, createParamInLocalStorage } from '../../setupTests';
 import { screen } from '@testing-library/react';
-
-const now = new Date().getTime();
+import { LocalStorageKey } from '../../constants/constants';
 
 const realStore = rootReducer.getState();
 const mockStore = createMockAppStore({
     ...realStore,
-    app: {
-        ...realStore.app,
-        paramRegistry: [
-            { id: 'test-01', lastModified: now - 10 * 60 * 1000 }, // 10 mins ago
-            { id: 'test-02', lastModified: now - 60 * 1000 }, // 1 min ago
-            { id: 'test-03' },
-        ],
-    },
 });
 
 const mockCallbacks = {
@@ -27,7 +18,23 @@ const mockCallbacks = {
 
 describe('ParamSelector', () => {
     it('Can sort params by last modified time', () => {
-        render(<ParamSelector {...mockCallbacks} />, { store: mockStore });
+        const now = new Date().getTime();
+
+        createParamInLocalStorage('test-01');
+        window.localStorage.setItem(
+            LocalStorageKey.PARAM_CONFIG_BY_ID + 'test-01',
+            JSON.stringify({ lastModified: now - 10 * 60 * 1000 })
+        ); // 10 mins ago
+
+        createParamInLocalStorage('test-02');
+        window.localStorage.setItem(
+            LocalStorageKey.PARAM_CONFIG_BY_ID + 'test-02',
+            JSON.stringify({ lastModified: now - 60 * 1000 })
+        ); // 10 mins ago
+
+        createParamInLocalStorage('test-03');
+
+        render(<ParamSelector {...mockCallbacks} />);
 
         const buttons = screen.getAllByRole('button');
         expect(buttons[0]).toHaveAccessibleName(/test-02/);

--- a/src/components/param-selector-view/param-selector.test.tsx
+++ b/src/components/param-selector-view/param-selector.test.tsx
@@ -4,7 +4,7 @@ import { render } from '../../test-utils';
 import ParamSelector from './param-selector';
 import { createMockAppStore, createParamInLocalStorage } from '../../setupTests';
 import { screen } from '@testing-library/react';
-import { LocalStorageKey } from '../../constants/constants';
+import { ParamConfig } from '../../constants/constants';
 
 const realStore = rootReducer.getState();
 const mockStore = createMockAppStore({
@@ -21,20 +21,16 @@ describe('ParamSelector', () => {
         const now = new Date().getTime();
 
         createParamInLocalStorage('test-01');
-        window.localStorage.setItem(
-            LocalStorageKey.PARAM_CONFIG_BY_ID + 'test-01',
-            JSON.stringify({ lastModified: now - 10 * 60 * 1000 })
-        ); // 10 mins ago
-
         createParamInLocalStorage('test-02');
-        window.localStorage.setItem(
-            LocalStorageKey.PARAM_CONFIG_BY_ID + 'test-02',
-            JSON.stringify({ lastModified: now - 60 * 1000 })
-        ); // 10 mins ago
-
         createParamInLocalStorage('test-03');
 
-        render(<ParamSelector {...mockCallbacks} />);
+        const paramRegistry: ParamConfig[] = [
+            { id: 'test-01', lastModified: now - 10 * 60 * 1000 }, // 10 mins ago
+            { id: 'test-02', lastModified: now - 60 * 1000 }, // 1 min ago
+            { id: 'test-03' },
+        ];
+
+        render(<ParamSelector paramRegistry={paramRegistry} {...mockCallbacks} />);
 
         const buttons = screen.getAllByRole('button');
         expect(buttons[0]).toHaveAccessibleName(/test-02/);

--- a/src/components/param-selector-view/param-selector.tsx
+++ b/src/components/param-selector-view/param-selector.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { useRootSelector } from '../../redux';
 import { ButtonGroup, Flex, IconButton, SystemStyleObject } from '@chakra-ui/react';
 import { getRelativeTime } from '../../util/utils';
 import { MdDelete } from 'react-icons/md';
 import { useTranslation } from 'react-i18next';
 import { RmgEnrichedButton } from '@railmapgen/rmg-components';
+import { getParamRegistry } from '../../util/param-manager-utils';
 
 interface ParamSelectorProps {
     selectedParam?: string;
@@ -35,7 +35,8 @@ export default function ParamSelector(props: ParamSelectorProps) {
     const { selectedParam, onParamSelect, onParamRemove } = props;
     const { t } = useTranslation();
 
-    const { paramRegistry } = useRootSelector(state => state.app);
+    // const { paramRegistry } = useRootSelector(state => state.app);
+    const paramRegistry = getParamRegistry();
 
     return (
         <Flex sx={styles}>

--- a/src/components/param-selector-view/param-selector.tsx
+++ b/src/components/param-selector-view/param-selector.tsx
@@ -4,9 +4,10 @@ import { getRelativeTime } from '../../util/utils';
 import { MdDelete } from 'react-icons/md';
 import { useTranslation } from 'react-i18next';
 import { RmgEnrichedButton } from '@railmapgen/rmg-components';
-import { getParamRegistry } from '../../util/param-manager-utils';
+import { ParamConfig } from '../../constants/constants';
 
 interface ParamSelectorProps {
+    paramRegistry: ParamConfig[];
     selectedParam?: string;
     onParamSelect: (id: string) => void;
     onParamRemove: (id: string) => void;
@@ -32,11 +33,8 @@ const styles: SystemStyleObject = {
 };
 
 export default function ParamSelector(props: ParamSelectorProps) {
-    const { selectedParam, onParamSelect, onParamRemove } = props;
+    const { paramRegistry, selectedParam, onParamSelect, onParamRemove } = props;
     const { t } = useTranslation();
-
-    // const { paramRegistry } = useRootSelector(state => state.app);
-    const paramRegistry = getParamRegistry();
 
     return (
         <Flex sx={styles}>

--- a/src/components/root/app-router.test.tsx
+++ b/src/components/root/app-router.test.tsx
@@ -51,7 +51,7 @@ describe('AppRouter', () => {
             render(<AppRouter />, { store: mockStore, route: '/?project=test-id' });
 
             const actions = mockStore.getActions();
-            expect(actions).toContainEqual({ type: 'app/setCurrentParamId', payload: 'test-id' });
+            expect(actions).toContainEqual({ type: 'app/setParamConfig', payload: { id: 'test-id' } });
             expect(actions).toContainEqual(expect.objectContaining({ type: 'SET_FULL_PARAM' }));
 
             expect(screen.getByRole('presentation', { name: 'Mock App View' })).toBeInTheDocument();
@@ -67,7 +67,7 @@ describe('AppRouter', () => {
         it('Can render app view if param is loaded', async () => {
             const mockStore = createMockAppStore({
                 ...realStore,
-                app: { ...realStore.app, currentParamId: 'test-id' },
+                app: { ...realStore.app, paramConfig: { id: 'test-id' } },
             });
             render(<AppRouter />, { store: mockStore, route: '/?project=test-id' });
 
@@ -93,7 +93,7 @@ describe('AppRouter', () => {
 
             // update redux store
             const actions = mockStore.getActions();
-            expect(actions).toContainEqual(expect.objectContaining({ type: 'app/setCurrentParamId' }));
+            expect(actions).toContainEqual(expect.objectContaining({ type: 'app/setParamConfig' }));
             expect(actions).toContainEqual(expect.objectContaining({ type: 'SET_FULL_PARAM' }));
 
             expect(screen.getByRole('presentation', { name: 'Mock App View' })).toBeInTheDocument();
@@ -105,7 +105,7 @@ describe('AppRouter', () => {
 
             // update redux store
             const actions = mockStore.getActions();
-            expect(actions).toContainEqual({ type: 'app/setCurrentParamId', payload: 'test-id' });
+            expect(actions).toContainEqual({ type: 'app/setParamConfig', payload: { id: 'test-id' } });
             expect(actions).toContainEqual({
                 type: 'SET_FULL_PARAM',
                 fullParam: expect.objectContaining({ line_num: 'test-id' }),
@@ -119,7 +119,7 @@ describe('AppRouter', () => {
             render(<AppRouter />, { store: mockStore, route: '/?project=test-id' });
 
             const actions = mockStore.getActions();
-            expect(actions).toContainEqual({ type: 'app/setCurrentParamId', payload: 'test-id' });
+            expect(actions).toContainEqual({ type: 'app/setParamConfig', payload: { id: 'test-id' } });
             expect(actions).toContainEqual(expect.objectContaining({ type: 'SET_FULL_PARAM' }));
 
             expect(screen.getByRole('presentation', { name: 'Mock App View' })).toBeInTheDocument();
@@ -131,7 +131,7 @@ describe('AppRouter', () => {
 
             // update redux store
             const actions = mockStore.getActions();
-            expect(actions).toContainEqual({ type: 'app/setCurrentParamId', payload: 'test-id-1' });
+            expect(actions).toContainEqual({ type: 'app/setParamConfig', payload: { id: 'test-id-1' } });
             expect(actions).toContainEqual({
                 type: 'SET_FULL_PARAM',
                 fullParam: expect.objectContaining({ line_num: 'test-id-1' }),
@@ -143,7 +143,7 @@ describe('AppRouter', () => {
         it('Can render app view if param is loaded', async () => {
             const mockStore = createMockAppStore({
                 ...realStore,
-                app: { ...realStore.app, currentParamId: 'test-id' },
+                app: { ...realStore.app, paramConfig: { id: 'test-id' } },
             });
             render(<AppRouter />, { store: mockStore, route: '/?project=test-id' });
 

--- a/src/components/root/app-router.tsx
+++ b/src/components/root/app-router.tsx
@@ -12,7 +12,7 @@ import { nanoid } from 'nanoid';
 export default function AppRouter() {
     const dispatch = useRootDispatch();
 
-    const { currentParamId } = useRootSelector(state => state.app);
+    const { paramConfig } = useRootSelector(state => state.app);
     const [searchParams, setSearchParams] = useSearchParams();
     const paramId = searchParams.get('project');
 
@@ -21,7 +21,7 @@ export default function AppRouter() {
     useEffect(() => {
         console.log('searchParam: project=' + paramId);
         if (paramId) {
-            if (paramId === currentParamId) {
+            if (paramId === paramConfig?.id) {
                 console.log('AppRouter:: Store param ID matches URL param ID. Rendering app view...');
                 setIsLoaded(true);
             } else {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -300,6 +300,7 @@ export enum LocalStorageKey {
     PARAM = 'rmg__param',
     PARAM_BY_ID = 'rmg__param:',
     PARAM_REGISTRY = 'rmg__paramRegistry',
+    PARAM_CONFIG_BY_ID = 'rmg__paramConfig:',
 }
 
 export enum Events {

--- a/src/redux/app/action.test.ts
+++ b/src/redux/app/action.test.ts
@@ -31,7 +31,7 @@ describe('AppAction', () => {
             mockStore.dispatch(readParam('test-id', LanguageCode.English));
 
             const actions = mockStore.getActions();
-            expect(actions).toContainEqual({ type: 'app/setCurrentParamId', payload: 'test-id' });
+            expect(actions).toContainEqual({ type: 'app/setParamConfig', payload: { id: 'test-id' } });
             expect(actions).toContainEqual({
                 type: 'SET_FULL_PARAM',
                 fullParam: expect.objectContaining({ line_num: 'test-id' }),
@@ -43,7 +43,7 @@ describe('AppAction', () => {
             mockStore.dispatch(readParam('test-id', LanguageCode.English));
 
             const actions = mockStore.getActions();
-            expect(actions).toContainEqual({ type: 'app/setCurrentParamId', payload: 'test-id' });
+            expect(actions).toContainEqual({ type: 'app/setParamConfig', payload: { id: 'test-id' } });
             expect(actions).toContainEqual({
                 type: 'SET_FULL_PARAM',
                 fullParam: expect.not.objectContaining({ line_num: 'test-id' }),
@@ -54,7 +54,7 @@ describe('AppAction', () => {
             mockStore.dispatch(readParam('test-id', LanguageCode.English));
 
             const actions = mockStore.getActions();
-            expect(actions).toContainEqual({ type: 'app/setCurrentParamId', payload: 'test-id' });
+            expect(actions).toContainEqual({ type: 'app/setParamConfig', payload: { id: 'test-id' } });
             expect(actions).toContainEqual({
                 type: 'SET_FULL_PARAM',
                 fullParam: expect.not.objectContaining({ line_num: 'test-id' }),

--- a/src/redux/app/action.ts
+++ b/src/redux/app/action.ts
@@ -1,14 +1,26 @@
 import { LanguageCode } from '@railmapgen/rmg-translate';
 import { RootDispatch } from '../index';
-import { LocalStorageKey, RMGParam, RmgStyle } from '../../constants/constants';
+import { LocalStorageKey, ParamConfig, RMGParam, RmgStyle } from '../../constants/constants';
 import { updateParam } from '../../utils';
 import { setFullParam } from '../param/action';
 import { initParam } from '../param/util';
-import { setCurrentParamId } from './app-slice';
+import { setParamConfig } from './app-slice';
 
 export const readParam = (paramId: string, language: LanguageCode) => {
     return (dispatch: RootDispatch) => {
-        dispatch(setCurrentParamId(paramId));
+        try {
+            const configStr = window.localStorage.getItem(LocalStorageKey.PARAM_CONFIG_BY_ID + paramId);
+            if (configStr === null) {
+                throw new Error(`Config for paramID=${paramId} does not exist in localStorage`);
+            }
+            const nextConfig: ParamConfig = { ...JSON.parse(configStr), id: paramId };
+            dispatch(setParamConfig(nextConfig));
+        } catch (err) {
+            console.warn('Failed to parse param config.', err);
+            console.log('Initiating new config for paramID=' + paramId);
+
+            dispatch(setParamConfig({ id: paramId }));
+        }
 
         try {
             const paramStr = window.localStorage.getItem(LocalStorageKey.PARAM_BY_ID + paramId);

--- a/src/redux/app/app-slice.test.ts
+++ b/src/redux/app/app-slice.test.ts
@@ -1,5 +1,5 @@
 import rootReducer from '../index';
-import appReducer, { closeGlobalAlert, setGlobalAlert, updateParamModifiedTime } from './app-slice';
+import appReducer, { closeGlobalAlert, setGlobalAlert } from './app-slice';
 import { createMockAppStore } from '../../setupTests';
 
 const realStore = rootReducer.getState();
@@ -55,28 +55,6 @@ describe('AppSlice', () => {
         it('Can close alert as expected', () => {
             const nextState = appReducer(initialState, closeGlobalAlert('info'));
             expect(nextState.globalAlerts).not.toHaveProperty('info');
-        });
-    });
-
-    describe('AppSlice - param registry', () => {
-        it('Can update last modified time for existing param as expected', () => {
-            const initialState = {
-                ...realStore.app,
-                paramRegistry: [{ id: 'test-id' }],
-            };
-            const nextState = appReducer(initialState, updateParamModifiedTime('test-id'));
-
-            expect(nextState.paramRegistry).toContainEqual({ id: 'test-id', lastModified: expect.any(Number) });
-        });
-
-        it('Can update last modified time for non-existing param as expected', () => {
-            const initialState = {
-                ...realStore.app,
-                paramRegistry: [],
-            };
-            const nextState = appReducer(initialState, updateParamModifiedTime('test-id'));
-
-            expect(nextState.paramRegistry).toContainEqual({ id: 'test-id', lastModified: expect.any(Number) });
         });
     });
 });

--- a/src/redux/app/app-slice.ts
+++ b/src/redux/app/app-slice.ts
@@ -4,6 +4,10 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface AppState {
     rmgStyle: RmgStyle;
+
+    /** keep only 1 param config in redux store to
+     *  avoid semantic error in multi-instance mode
+     */
     paramConfig?: ParamConfig;
     canvasScale: number;
     canvasToShow: CanvasType[];
@@ -38,9 +42,10 @@ const appSlice = createSlice({
             state.paramConfig = action.payload;
         },
 
-        updateParamModifiedTime: state => {
+        // to be called in ListenerMiddleware only
+        updateParamModifiedTime: (state, action: PayloadAction<number>) => {
             if (state.paramConfig) {
-                state.paramConfig.lastModified = Date.now();
+                state.paramConfig.lastModified = action.payload;
             }
         },
 

--- a/src/redux/app/app-slice.ts
+++ b/src/redux/app/app-slice.ts
@@ -4,8 +4,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface AppState {
     rmgStyle: RmgStyle;
-    currentParamId?: string;
-    paramRegistry: ParamConfig[];
+    paramConfig?: ParamConfig;
     canvasScale: number;
     canvasToShow: CanvasType[];
     sidePanelMode: SidePanelMode;
@@ -19,8 +18,7 @@ interface AppState {
 
 const initialState: AppState = {
     rmgStyle: RmgStyle.MTR,
-    currentParamId: undefined,
-    paramRegistry: [],
+    paramConfig: undefined,
     canvasScale: 1,
     canvasToShow: Object.values(CanvasType),
     sidePanelMode: SidePanelMode.CLOSE,
@@ -36,33 +34,14 @@ const appSlice = createSlice({
     name: 'app',
     initialState,
     reducers: {
-        setCurrentParamId: (state, action: PayloadAction<string>) => {
-            state.currentParamId = action.payload;
+        setParamConfig: (state, action: PayloadAction<ParamConfig>) => {
+            state.paramConfig = action.payload;
         },
 
-        setParamRegistry: (state, action: PayloadAction<ParamConfig[]>) => {
-            state.paramRegistry = action.payload;
-        },
-
-        updateParamModifiedTime: (state, action: PayloadAction<string>) => {
-            if (state.paramRegistry.some(config => config.id === action.payload)) {
-                state.paramRegistry = state.paramRegistry.map(config => {
-                    if (config.id === action.payload) {
-                        return { ...config, lastModified: new Date().getTime() };
-                    } else {
-                        return config;
-                    }
-                });
-            } else {
-                state.paramRegistry = [
-                    ...state.paramRegistry,
-                    { id: action.payload, lastModified: new Date().getTime() },
-                ];
+        updateParamModifiedTime: state => {
+            if (state.paramConfig) {
+                state.paramConfig.lastModified = Date.now();
             }
-        },
-
-        removeParam: (state, action: PayloadAction<string>) => {
-            state.paramRegistry = state.paramRegistry.filter(config => config.id !== action.payload);
         },
 
         setCanvasScale: (state, action: PayloadAction<number>) => {
@@ -125,10 +104,8 @@ const appSlice = createSlice({
 });
 
 export const {
-    setCurrentParamId,
-    setParamRegistry,
+    setParamConfig,
     updateParamModifiedTime,
-    removeParam,
     setCanvasScale,
     setCanvasToShow,
     setSidePanelMode,

--- a/src/util/param-manager-utils.test.ts
+++ b/src/util/param-manager-utils.test.ts
@@ -13,17 +13,14 @@ describe('ParamMgrUtils', () => {
             expect(result).toHaveLength(0);
         });
 
-        it('Can reset param registry if registry in localStorage is malformat', () => {
-            window.localStorage.setItem(LocalStorageKey.PARAM_REGISTRY, JSON.stringify({ x: 1 }));
-            const result = loadParamRegistry();
-            expect(result).toHaveLength(0);
-        });
-
         it('Can load param registry from localStorage as expected', () => {
-            window.localStorage.setItem(LocalStorageKey.PARAM_REGISTRY, JSON.stringify([{ id: 'test-id' }]));
+            window.localStorage.setItem(
+                LocalStorageKey.PARAM_CONFIG_BY_ID + 'test-id',
+                JSON.stringify({ lastModified: Date.now() })
+            );
             const result = loadParamRegistry();
             expect(result).toHaveLength(1);
-            expect(result).toContainEqual(expect.objectContaining({ id: 'test-id' }));
+            expect(result).toContainEqual({ id: 'test-id', lastModified: expect.any(Number) });
         });
     });
 
@@ -79,8 +76,12 @@ describe('ParamMgrUtils', () => {
             createParamInLocalStorage('test-01');
             createParamInLocalStorage('test-03');
             window.localStorage.setItem(
-                LocalStorageKey.PARAM_REGISTRY,
-                JSON.stringify([{ id: 'test-01' }, { id: 'test-02' }])
+                LocalStorageKey.PARAM_CONFIG_BY_ID + 'test-01',
+                JSON.stringify({ lastModified: Date.now() })
+            );
+            window.localStorage.setItem(
+                LocalStorageKey.PARAM_CONFIG_BY_ID + 'test-02',
+                JSON.stringify({ lastModified: Date.now() })
             );
 
             const result = getParamRegistry();


### PR DESCRIPTION
Why? To prevent semantic error if multiple instances are updating param config (last modified time) in localStorage at the same time.