### PR TITLE
feat: implement batch station editing and multi-selection support

### DIFF
--- a/src/components/ag-grid/station-ag-grid.tsx
+++ b/src/components/ag-grid/station-ag-grid.tsx
@@ -13,7 +13,7 @@ import {
 import { RmgStyle, SidePanelMode, StationInfo } from '../../constants/constants';
 import { useTranslation } from 'react-i18next';
 import { HStack } from '@chakra-ui/react';
-import { setIsShareTrackEnabled, setSelectedStation, setSidePanelMode } from '../../redux/app/app-slice';
+import { setIsShareTrackEnabled, setSelectedStations, setSidePanelMode } from '../../redux/app/app-slice';
 import { getRowSpanForColine } from '../../redux/param/coline-action';
 import GzmtrStationCode from './gzmtr-station-code';
 import { MonoColour } from '@railmapgen/rmg-palette-resources';
@@ -31,7 +31,7 @@ interface StationAgGridProps {
 type RowDataType = StationInfo & { id: string; rowSpan: [number, string | undefined] };
 
 const rowSelection: RowSelectionOptions = {
-    mode: 'singleRow',
+    mode: 'multiRow',
     checkboxes: false,
     enableClickSelection: true,
 };
@@ -168,7 +168,7 @@ export default function StationAgGrid(props: StationAgGridProps) {
 
         if (selectedRowIds?.length) {
             dispatch(setSidePanelMode(SidePanelMode.STATION));
-            dispatch(setSelectedStation(selectedRowIds[0]));
+            dispatch(setSelectedStations(selectedRowIds));
             dispatch(setIsShareTrackEnabled(undefined));
         }
     }, []);

--- a/src/components/modal/add-station-modal.test.tsx
+++ b/src/components/modal/add-station-modal.test.tsx
@@ -131,7 +131,7 @@ describe('AddStationModal', () => {
             expect(addedStations).toHaveLength(1);
 
             // open side panel
-            expect(mockStore.getState().app.selectedStation).toBe(addedStations[0]);
+            expect(mockStore.getState().app.selectedStations[0]).toBe(addedStations[0]);
             expect(mockStore.getState().app.sidePanelMode).toBe(SidePanelMode.STATION);
         });
     });

--- a/src/components/modal/remove-confirm-modal.test.tsx
+++ b/src/components/modal/remove-confirm-modal.test.tsx
@@ -42,7 +42,7 @@ describe('RemoveConfirmModal', () => {
         const mockStore = createTestStore({
             app: {
                 ...realStore.app,
-                selectedStation: 'stn1',
+                selectedStations: ['stn1'],
             },
             param: {
                 ...realStore.param,
@@ -99,7 +99,7 @@ describe('RemoveConfirmModal', () => {
         const mockStore = createTestStore({
             app: {
                 ...realStore.app,
-                selectedStation: 'stn2',
+                selectedStations: ['stn2'],
             },
             param: {
                 ...realStore.param,
@@ -115,6 +115,6 @@ describe('RemoveConfirmModal', () => {
         // assertions
         expect(mockStore.getState().param.stn_list).not.toHaveProperty('stn2'); // removal of station
         expect(mockStore.getState().app.sidePanelMode).toBe(SidePanelMode.CLOSE); // close side panel
-        expect(mockStore.getState().app.selectedStation).toBe('linestart'); // reset station selection
+        expect(mockStore.getState().app.selectedStations[0]).toBe('linestart'); // reset station selection
     });
 });

--- a/src/components/modal/remove-confirm-modal.tsx
+++ b/src/components/modal/remove-confirm-modal.tsx
@@ -30,7 +30,7 @@ export default function RemoveConfirmModal(props: RemoveConfirmModalProps) {
     const { t } = useTranslation();
 
     const dispatch = useRootDispatch();
-    const selectedStation = useRootSelector(state => state.app.selectedStation);
+    const selectedStation = useRootSelector(state => state.app.selectedStations[0]);
 
     const [error, setError] = useState(false);
 

--- a/src/components/side-panel/batch-station-edit-panel.tsx
+++ b/src/components/side-panel/batch-station-edit-panel.tsx
@@ -1,0 +1,92 @@
+import { Box, Button, HStack, Text, VStack } from '@chakra-ui/react';
+import { RmgFields, RmgSidePanelFooter } from '@railmapgen/rmg-components';
+import { useTranslation } from 'react-i18next';
+import { Facilities, Services, TEMP } from '../../constants/constants';
+import { useRootDispatch, useRootSelector } from '../../redux';
+import { updateStationsProperty } from '../../redux/param/action';
+import { checkStationCouldBeRemoved, removeStation } from '../../redux/param/remove-station-action';
+import { setSelectedStations } from '../../redux/app/app-slice';
+
+import { SidePanelMode } from '../../constants/constants';
+import { setSidePanelMode } from '../../redux/app/app-slice';
+import { useStationEditFields } from './station-side-panel/use-station-edit-fields';
+
+export default function BatchStationEditPanel() {
+    const { t } = useTranslation();
+    const dispatch = useRootDispatch();
+
+    const selectedStations = useRootSelector(state => state.app.selectedStations);
+    const { style, stn_list, loop } = useRootSelector(state => state.param);
+
+    if (!selectedStations || selectedStations.length <= 1) return null;
+
+    const firstStation = stn_list[selectedStations[0]];
+    const commonServices = firstStation?.services || [];
+    const commonFacility = firstStation?.facility || '';
+    const commonOneLine = firstStation?.one_line || false;
+    const commonIntPadding = firstStation?.int_padding;
+    const commonCharacterSpacing = firstStation?.character_spacing;
+    const commonUnderConstruction = firstStation?.underConstruction;
+
+    const fields = useStationEditFields({
+        style,
+        loop,
+        values: {
+            services: commonServices,
+            facility: commonFacility,
+            one_line: commonOneLine,
+            int_padding: commonIntPadding,
+            character_spacing: commonCharacterSpacing,
+            underConstruction: commonUnderConstruction,
+        },
+        handlers: {
+            onServicesChange: (val: Services[]) => dispatch(updateStationsProperty(selectedStations, 'services', val)),
+            onFacilityChange: (val: string | number) =>
+                dispatch(updateStationsProperty(selectedStations, 'facility', val as Facilities)),
+            onOneLineChange: (val: boolean) => dispatch(updateStationsProperty(selectedStations, 'one_line', val)),
+            onIntPaddingChange: (val: number) => dispatch(updateStationsProperty(selectedStations, 'int_padding', val)),
+            onCharacterSpacingChange: (val: number) =>
+                dispatch(updateStationsProperty(selectedStations, 'character_spacing', val)),
+            onUnderConstructionChange: (val: boolean | TEMP) =>
+                dispatch(updateStationsProperty(selectedStations, 'underConstruction', val)),
+        },
+    });
+
+    const handleDelete = () => {
+        dispatch((dispatch, getState) => {
+            const currentSelected = getState().app.selectedStations;
+            currentSelected.forEach(id => {
+                if (getState().param.stn_list[id]) {
+                    if (checkStationCouldBeRemoved(id)(dispatch, getState)) {
+                        dispatch(removeStation(id));
+                    }
+                }
+            });
+            dispatch(setSelectedStations([]));
+            dispatch(setSidePanelMode(SidePanelMode.CLOSE));
+        });
+    };
+
+    return (
+        <VStack spacing={4} align="stretch">
+            <Box p={4}>
+                <Text mb={4}>
+                    {t('StationSidePanel.batch_selected', {
+                        count: selectedStations.length,
+                        defaultValue: `Selected ${selectedStations.length} stations`,
+                    })}
+                </Text>
+                <RmgFields fields={fields} />
+            </Box>
+
+            <RmgSidePanelFooter>
+                <HStack justify="space-between">
+                    <Button size="sm" variant="outline" onClick={handleDelete}>
+                        {t('StationSidePanel.footer.remove')}
+                    </Button>
+                </HStack>
+            </RmgSidePanelFooter>
+        </VStack>
+    );
+}
+

--- a/src/components/side-panel/side-panel.tsx
+++ b/src/components/side-panel/side-panel.tsx
@@ -3,6 +3,7 @@ import { useRootSelector } from '../../redux';
 import { closePaletteAppClip, onPaletteAppClipEmit, setSidePanelMode } from '../../redux/app/app-slice';
 import { useDispatch } from 'react-redux';
 import { SidePanelMode } from '../../constants/constants';
+import BatchStationEditPanel from './batch-station-edit-panel';
 import StationSidePanel from './station-side-panel/station-side-panel';
 import StyleSidePanel from './style-side-panel/style-side-panel';
 import { RmgMultiLineString, RmgSidePanel, RmgSidePanelHeader } from '@railmapgen/rmg-components';
@@ -17,14 +18,20 @@ export default function SidePanel() {
     const { t } = useTranslation();
     const dispatch = useDispatch();
 
-    const { sidePanelMode, selectedStation, paletteAppClipInput } = useRootSelector(state => state.app);
+    const { sidePanelMode, selectedStations, paletteAppClipInput } = useRootSelector(state => state.app);
+    const selectedStation = selectedStations[0] || 'linestart';
     const name = useRootSelector(state => state.param.stn_list[selectedStation]?.localisedName);
 
     const mode: Record<SidePanelMode, { header: ReactNode; body?: ReactNode; footer?: ReactNode }> = {
         STATION: {
-            header: <RmgMultiLineString text={name?.zh + '/' + name?.en || ''} />,
-            body: <StationSidePanel />,
-            footer: <StationSidePanelFooter />,
+            header:
+                selectedStations && selectedStations.length > 1 ? (
+                    t('StationSidePanel.batch_edit')
+                ) : (
+                    <RmgMultiLineString text={name?.zh + '/' + name?.en || ''} />
+                ),
+            body: selectedStations && selectedStations.length > 1 ? <BatchStationEditPanel /> : <StationSidePanel />,
+            footer: selectedStations && selectedStations.length > 1 ? null : <StationSidePanelFooter />,
         },
         STYLE: { header: t('StyleSidePanel.header'), body: <StyleSidePanel /> },
         BRANCH: { header: t('BranchSidePanel.header'), body: <BranchSidePanel /> },

--- a/src/components/side-panel/station-side-panel/branch-section.tsx
+++ b/src/components/side-panel/station-side-panel/branch-section.tsx
@@ -13,7 +13,7 @@ export default function BranchSection() {
     const { t } = useTranslation();
     const dispatch = useRootDispatch();
 
-    const selectedStation = useRootSelector(state => state.app.selectedStation);
+    const selectedStation = useRootSelector(state => state.app.selectedStations[0]);
     const stationList = useRootSelector(state => state.param.stn_list);
     const { parents, children, branch } = stationList[selectedStation];
 

--- a/src/components/side-panel/station-side-panel/info-section.tsx
+++ b/src/components/side-panel/station-side-panel/info-section.tsx
@@ -14,7 +14,7 @@ export default function InfoSection() {
     const { t } = useTranslation();
     const dispatch = useRootDispatch();
 
-    const selectedStation = useRootSelector(state => state.app.selectedStation);
+    const selectedStation = useRootSelector(state => state.app.selectedStations[0]);
     console.log('InfoSection:: Rendering for', selectedStation);
     const style = useRootSelector(state => state.param.style);
     const { num, localisedName, localisedSecondaryName } = useRootSelector(

--- a/src/components/side-panel/station-side-panel/interchange-section.test.tsx
+++ b/src/components/side-panel/station-side-panel/interchange-section.test.tsx
@@ -12,7 +12,7 @@ const testStationId = realStore.param.stn_list.linestart.children[0];
 describe('InterchangeSection', () => {
     it('Can render InterchangeCard with headings as expected', () => {
         const mockStore = createTestStore({
-            app: { ...realStore.app, selectedStation: testStationId },
+            app: { ...realStore.app, selectedStations: [testStationId] },
             param: {
                 ...realStore.param,
                 style: RmgStyle.GZMTR,
@@ -42,7 +42,7 @@ describe('InterchangeSection', () => {
 
     it('Can handle add interchange group as expected', () => {
         const mockStore = createTestStore({
-            app: { ...realStore.app, selectedStation: testStationId },
+            app: { ...realStore.app, selectedStations: [testStationId] },
             param: {
                 ...realStore.param,
                 style: RmgStyle.GZMTR,

--- a/src/components/side-panel/station-side-panel/interchange-section.tsx
+++ b/src/components/side-panel/station-side-panel/interchange-section.tsx
@@ -20,7 +20,7 @@ export default function InterchangeSection() {
     const { t } = useTranslation();
     const dispatch = useRootDispatch();
 
-    const selectedStation = useRootSelector(state => state.app.selectedStation);
+    const selectedStation = useRootSelector(state => state.app.selectedStations[0]);
     const { theme, style } = useRootSelector(state => state.param);
     const { transfer } = useRootSelector(state => state.param.stn_list[selectedStation]);
 

--- a/src/components/side-panel/station-side-panel/more-section.tsx
+++ b/src/components/side-panel/station-side-panel/more-section.tsx
@@ -1,7 +1,7 @@
 import { Box, Heading } from '@chakra-ui/react';
-import { RmgButtonGroup, RmgFields, RmgFieldsField } from '@railmapgen/rmg-components';
+import { RmgFields } from '@railmapgen/rmg-components';
 import { useTranslation } from 'react-i18next';
-import { FACILITIES, Facilities, RmgStyle, Services, TEMP } from '../../../constants/constants';
+import { Facilities, Services, TEMP } from '../../../constants/constants';
 import { useRootDispatch, useRootSelector } from '../../../redux';
 import {
     updateStationCharacterSpacing,
@@ -14,136 +14,43 @@ import {
     updateStationServices,
     updateStationUnderConstruction,
 } from '../../../redux/param/action';
+import { useStationEditFields } from './use-station-edit-fields';
 
 export default function MoreSection() {
     const { t } = useTranslation();
     const dispatch = useRootDispatch();
 
-    const selectedStation = useRootSelector(state => state.app.selectedStation);
+    const selectedStation = useRootSelector(state => state.app.selectedStations[0]);
     const { style, loop } = useRootSelector(state => state.param);
     const { services, facility, loop_pivot, one_line, int_padding, character_spacing, underConstruction } =
         useRootSelector(state => state.param.stn_list[selectedStation]);
 
-    const serviceSelections = Object.values(Services).map(service => {
-        return {
-            label: t('StationSidePanel.more.' + service),
-            value: service,
-            disabled: service === Services.local && style !== RmgStyle.SHMetro,
-        };
+    const fields = useStationEditFields({
+        style,
+        loop,
+        values: {
+            services,
+            facility: facility || '',
+            loop_pivot,
+            one_line,
+            int_padding,
+            character_spacing,
+            underConstruction,
+        },
+        handlers: {
+            onServicesChange: (val: Services[]) => dispatch(updateStationServices(selectedStation, val)),
+            onFacilityChange: (val: string | number) =>
+                dispatch(updateStationFacility(selectedStation, val as Facilities | '')),
+            onLoopPivotChange: (val: boolean) => dispatch(updateStationLoopPivot(selectedStation, val)),
+            onOneLineChange: (val: boolean) => dispatch(updateStationOneLine(selectedStation, val)),
+            onIntPaddingChange: (val: number) => dispatch(updateStationIntPadding(selectedStation, val)),
+            onCharacterSpacingChange: (val: number) => dispatch(updateStationCharacterSpacing(selectedStation, val)),
+            onUnderConstructionChange: (val: boolean | TEMP) =>
+                dispatch(updateStationUnderConstruction(selectedStation, val)),
+            onApplyIntPaddingToAll: () => dispatch(updateStationIntPaddingToAll(selectedStation)),
+            onApplyCharacterSpacingToAll: () => dispatch(updateStationCharacterSpacingToAll(selectedStation)),
+        },
     });
-
-    const mtrFacilityOptions = Object.fromEntries(
-        Object.entries(FACILITIES)
-            .filter(([f]) => !['railway'].includes(f))
-            .map(([f, name]) => [f, t(name)])
-    );
-    const shmetroFacilityOptions = Object.fromEntries(
-        Object.entries(FACILITIES)
-            .filter(([f]) => !['np360'].includes(f))
-            .map(([f, name]) => [f, t(name)])
-    );
-
-    const fields: RmgFieldsField[] = [
-        {
-            type: 'custom',
-            label: t('StationSidePanel.more.service'),
-            component: (
-                <RmgButtonGroup
-                    selections={serviceSelections}
-                    defaultValue={services}
-                    onChange={services => dispatch(updateStationServices(selectedStation, services))}
-                    multiSelect
-                />
-            ),
-            hidden: ![RmgStyle.GZMTR, RmgStyle.SHMetro].includes(style),
-        },
-        {
-            type: 'select',
-            label: t('StationSidePanel.more.facility'),
-            value: facility || '',
-            options: { '': t('None'), ...(style === RmgStyle.MTR ? mtrFacilityOptions : shmetroFacilityOptions) },
-            onChange: value => dispatch(updateStationFacility(selectedStation, value as Facilities | '')),
-            hidden: ![RmgStyle.MTR, RmgStyle.SHMetro].includes(style),
-        },
-        {
-            type: 'switch',
-            label: t('StationSidePanel.more.pivot'),
-            isChecked: loop_pivot,
-            onChange: checked => dispatch(updateStationLoopPivot(selectedStation, checked)),
-            hidden: ![RmgStyle.GZMTR, RmgStyle.SHMetro].includes(style) || !loop,
-            minW: 'full',
-            oneLine: true,
-        },
-        {
-            type: 'switch',
-            label: t('StationSidePanel.more.oneLine'),
-            isChecked: one_line,
-            onChange: checked => dispatch(updateStationOneLine(selectedStation, checked)),
-            hidden: ![RmgStyle.SHMetro].includes(style),
-            minW: 'full',
-            oneLine: true,
-        },
-        {
-            type: 'input',
-            label: t('StationSidePanel.more.intPadding'),
-            value: int_padding.toString(),
-            validator: val => Number.isInteger(val),
-            onChange: val => dispatch(updateStationIntPadding(selectedStation, Number(val))),
-            hidden: ![RmgStyle.SHMetro].includes(style),
-        },
-        {
-            type: 'custom',
-            label: t('StationSidePanel.more.intPaddingApplyGlobal'),
-            component: (
-                <RmgButtonGroup
-                    selections={[{ label: t('StationSidePanel.more.apply'), value: '', disabled: false }]}
-                    defaultValue=""
-                    onChange={() => dispatch(updateStationIntPaddingToAll(selectedStation))}
-                />
-            ),
-            oneLine: true,
-            hidden: ![RmgStyle.SHMetro].includes(style),
-        },
-        {
-            type: 'input',
-            label: t('StationSidePanel.more.characterSpacing'),
-            value: character_spacing.toString(),
-            validator: val => Number.isInteger(val),
-            onChange: val => dispatch(updateStationCharacterSpacing(selectedStation, Number(val))),
-            hidden: ![RmgStyle.SHSuburbanRailway].includes(style),
-        },
-        {
-            type: 'custom',
-            label: t('StationSidePanel.more.intPaddingApplyGlobal'),
-            component: (
-                <RmgButtonGroup
-                    selections={[{ label: t('StationSidePanel.more.apply'), value: '', disabled: false }]}
-                    defaultValue=""
-                    onChange={() => dispatch(updateStationCharacterSpacingToAll(selectedStation))}
-                />
-            ),
-            oneLine: true,
-            hidden: ![RmgStyle.SHSuburbanRailway].includes(style),
-        },
-        {
-            type: 'custom',
-            label: t('Under construction'),
-            component: (
-                <RmgButtonGroup
-                    selections={
-                        [
-                            { label: t('No'), value: false },
-                            { label: t('Temporary'), value: 'temp' },
-                            { label: t('Yes'), value: true },
-                        ] as { label: string; value: boolean | TEMP }[]
-                    }
-                    defaultValue={underConstruction ?? false}
-                    onChange={uc => dispatch(updateStationUnderConstruction(selectedStation, uc))}
-                />
-            ),
-            hidden: ![RmgStyle.GZMTR].includes(style),
-        },
-    ];
 
     return (
         <Box p={1}>
@@ -155,3 +62,4 @@ export default function MoreSection() {
         </Box>
     );
 }
+

--- a/src/components/side-panel/station-side-panel/station-side-panel-footer.tsx
+++ b/src/components/side-panel/station-side-panel/station-side-panel-footer.tsx
@@ -11,7 +11,7 @@ export default function StationSidePanelFooter() {
     const { t } = useTranslation();
     const dispatch = useRootDispatch();
 
-    const { selectedStation } = useRootSelector(state => state.app);
+    const selectedStation = useRootSelector(state => state.app.selectedStations[0]);
     const { loop, style } = useRootSelector(state => state.param);
 
     const [isRemoveModalOpen, setIsRemoveModalOpen] = useState(false);

--- a/src/components/side-panel/station-side-panel/use-station-edit-fields.tsx
+++ b/src/components/side-panel/station-side-panel/use-station-edit-fields.tsx
@@ -1,0 +1,185 @@
+import { useTranslation } from 'react-i18next';
+import { FACILITIES, RmgStyle, Services, TEMP } from '../../../constants/constants';
+import { RmgButtonGroup, RmgFieldsField } from '@railmapgen/rmg-components';
+
+interface UseStationEditFieldsProps {
+    style: RmgStyle;
+    values: {
+        services: Services[];
+        facility: string;
+        loop_pivot?: boolean;
+        one_line: boolean;
+        int_padding?: number;
+        character_spacing?: number;
+        underConstruction?: boolean | TEMP;
+    };
+    handlers: {
+        onServicesChange: (val: Services[]) => void;
+        onFacilityChange: (val: string | number) => void;
+        onLoopPivotChange?: (val: boolean) => void;
+        onOneLineChange: (val: boolean) => void;
+        onIntPaddingChange: (val: number) => void;
+        onCharacterSpacingChange: (val: number) => void;
+        onUnderConstructionChange: (val: boolean | TEMP) => void;
+        // Optional global apply handlers (only for single station mode)
+        onApplyIntPaddingToAll?: () => void;
+        onApplyCharacterSpacingToAll?: () => void;
+    };
+    loop?: boolean;
+}
+
+// Constants for configuration
+const SERVICE_ALLOW_CONFIG: Record<string, Services[]> = {
+    [RmgStyle.GZMTR]: [Services.express, Services.direct], // Only express and direct services allowed for Guangzhou Metro
+    default: Object.values(Services), // All services allowed by default (e.g. for SHMetro)
+};
+
+const FACILITY_ALLOW_CONFIG: Record<string, string[]> = {
+    [RmgStyle.MTR]: ['airport', 'hsr', 'disney', 'np360'],
+    [RmgStyle.SHMetro]: ['airport', 'hsr', 'railway', 'disney'],
+    default: Object.keys(FACILITIES),
+};
+
+export const useStationEditFields = (props: UseStationEditFieldsProps): RmgFieldsField[] => {
+    const { t } = useTranslation();
+    const { style, values, handlers, loop } = props;
+
+    // Filter available train services based on current style
+    const allowedServices = SERVICE_ALLOW_CONFIG[style] || SERVICE_ALLOW_CONFIG.default;
+    const serviceSelections = Object.values(Services).map(service => ({
+        label: t('StationSidePanel.more.' + service),
+        value: service,
+        disabled: !allowedServices.includes(service),
+    }));
+
+    // Filter available facilities (like toilets, elevators) based on current style
+    const allowedFacilities = FACILITY_ALLOW_CONFIG[style] || FACILITY_ALLOW_CONFIG.default;
+    const facilityOptions = Object.fromEntries([
+        ['', t('None')],
+        ...Object.entries(FACILITIES)
+            .filter(([f]) => allowedFacilities.includes(f))
+            .map(([f, name]) => [f, t(name)]),
+    ]);
+
+    const fields: RmgFieldsField[] = [
+        {
+            type: 'custom',
+            label: t('StationSidePanel.more.service'),
+            component: (
+                <RmgButtonGroup
+                    selections={serviceSelections}
+                    defaultValue={values.services}
+                    onChange={handlers.onServicesChange}
+                    multiSelect
+                />
+            ),
+            hidden: ![RmgStyle.GZMTR, RmgStyle.SHMetro].includes(style),
+        },
+        {
+            type: 'select',
+            label: t('StationSidePanel.more.facility'),
+            value: values.facility,
+            options: facilityOptions,
+            onChange: handlers.onFacilityChange,
+            hidden: ![RmgStyle.MTR, RmgStyle.SHMetro].includes(style),
+        },
+        // Loop Pivot (Specific to loop lines)
+        ...(handlers.onLoopPivotChange
+            ? ([
+                  {
+                      type: 'switch',
+                      label: t('StationSidePanel.more.pivot'),
+                      isChecked: values.loop_pivot ?? false,
+                      onChange: handlers.onLoopPivotChange,
+                      hidden: ![RmgStyle.GZMTR, RmgStyle.SHMetro].includes(style) || !loop,
+                      oneLine: true,
+                      minW: 'full',
+                  },
+              ] as RmgFieldsField[])
+            : []),
+        {
+            type: 'switch',
+            label: t('StationSidePanel.more.oneLine'),
+            isChecked: values.one_line,
+            onChange: handlers.onOneLineChange,
+            hidden: ![RmgStyle.SHMetro].includes(style),
+            oneLine: true,
+            minW: 'full',
+        },
+        {
+            type: 'input',
+            label: t('StationSidePanel.more.intPadding'),
+            value: values.int_padding?.toString() || '',
+            validator: val => !isNaN(Number(val)),
+            onChange: val => handlers.onIntPaddingChange(Number(val)),
+            hidden: ![RmgStyle.SHMetro].includes(style),
+            debouncedDelay: 300,
+        },
+        // Global apply for int_padding (Single station only)
+        // When the handler is provided, it will be appended as an additional field
+        ...(handlers.onApplyIntPaddingToAll
+            ? ([
+                  {
+                      type: 'custom',
+                      label: t('StationSidePanel.more.intPaddingApplyGlobal'),
+                      component: (
+                          <RmgButtonGroup
+                              selections={[{ label: t('StationSidePanel.more.apply'), value: '', disabled: false }]}
+                              defaultValue=""
+                              onChange={handlers.onApplyIntPaddingToAll}
+                          />
+                      ),
+                      oneLine: true,
+                      hidden: ![RmgStyle.SHMetro].includes(style),
+                  },
+              ] as RmgFieldsField[])
+            : []),
+        {
+            type: 'input',
+            label: t('StationSidePanel.more.characterSpacing'),
+            value: values.character_spacing?.toString() || '',
+            validator: val => !isNaN(Number(val)),
+            onChange: val => handlers.onCharacterSpacingChange(Number(val)),
+            hidden: ![RmgStyle.SHSuburbanRailway].includes(style),
+            debouncedDelay: 300,
+        },
+        // Global apply for character_spacing (Single station only)
+        ...(handlers.onApplyCharacterSpacingToAll
+            ? ([
+                  {
+                      type: 'custom',
+                      label: t('StationSidePanel.more.intPaddingApplyGlobal'),
+                      component: (
+                          <RmgButtonGroup
+                              selections={[{ label: t('StationSidePanel.more.apply'), value: '', disabled: false }]}
+                              defaultValue=""
+                              onChange={handlers.onApplyCharacterSpacingToAll}
+                          />
+                      ),
+                      oneLine: true,
+                      hidden: ![RmgStyle.SHSuburbanRailway].includes(style),
+                  },
+              ] as RmgFieldsField[])
+            : []),
+        {
+            type: 'custom',
+            label: t('Under construction'),
+            component: (
+                <RmgButtonGroup
+                    selections={
+                        [
+                            { label: t('No'), value: false },
+                            { label: t('Temporary'), value: 'temp' },
+                            { label: t('Yes'), value: true },
+                        ] as { label: string; value: boolean | TEMP }[]
+                    }
+                    defaultValue={values.underConstruction ?? false}
+                    onChange={handlers.onUnderConstructionChange}
+                />
+            ),
+            hidden: ![RmgStyle.GZMTR].includes(style),
+        },
+    ];
+
+    return fields;
+};

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -136,6 +136,8 @@
     },
 
     "StationSidePanel": {
+        "batch_edit": "Batch Edit",
+        "batch_selected": "Selected {{count}} stations",
         "info": {
             "title": "Station info",
             "num": "Station code",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -134,6 +134,8 @@
     },
 
     "StationSidePanel": {
+        "batch_edit": "一括編集",
+        "batch_selected": "{{count}} 駅を選択中",
         "info": {
             "title": "駅情報",
             "num": "駅番号",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -133,6 +133,8 @@
     },
 
     "StationSidePanel": {
+        "batch_edit": "일괄 편집",
+        "batch_selected": "{{count}}개 역 선택됨",
         "info": {
             "title": "역 정보",
             "num": "역 번호",

--- a/src/i18n/translations/zh-Hans.json
+++ b/src/i18n/translations/zh-Hans.json
@@ -134,6 +134,8 @@
     },
 
     "StationSidePanel": {
+        "batch_edit": "批量编辑",
+        "batch_selected": "已选中 {{count}} 个车站",
         "info": {
             "title": "车站资讯",
             "num": "车站编号",

--- a/src/i18n/translations/zh-Hant.json
+++ b/src/i18n/translations/zh-Hant.json
@@ -127,6 +127,8 @@
         }
     },
     "StationSidePanel": {
+        "batch_edit": "批次編輯",
+        "batch_selected": "已選取 {{count}} 個車站",
         "info": {
             "title": "車站資訊",
             "num": "車站編碼",

--- a/src/redux/app/app-slice.ts
+++ b/src/redux/app/app-slice.ts
@@ -13,7 +13,8 @@ interface AppState {
     canvasScale: number;
     canvasToShow: CanvasType[];
     sidePanelMode: SidePanelMode;
-    selectedStation: string;
+    // selectedStation: string; // Removed as redundant
+    selectedStations: string[];
     selectedColine?: number;
     selectedBranch: number;
     isShareTrackEnabled?: string[]; // for main line only, store the selections
@@ -29,7 +30,8 @@ const initialState: AppState = {
     canvasScale: 1,
     canvasToShow: Object.values(CanvasType),
     sidePanelMode: SidePanelMode.CLOSE,
-    selectedStation: 'linestart',
+    // selectedStation: 'linestart',
+    selectedStations: ['linestart'],
     selectedColine: undefined,
     selectedBranch: 0,
     isShareTrackEnabled: undefined,
@@ -65,7 +67,8 @@ const appSlice = createSlice({
         },
 
         setSelectedStation: (state, action: PayloadAction<string>) => {
-            state.selectedStation = action.payload;
+            // state.selectedStation = action.payload;
+            state.selectedStations = [action.payload];
         },
 
         setSelectedColine: (state, action: PayloadAction<number>) => {
@@ -122,6 +125,10 @@ const appSlice = createSlice({
             state.paletteAppClipOutput = action.payload;
             state.paletteAppClipInput = undefined;
         },
+
+        setSelectedStations: (state, action: PayloadAction<string[]>) => {
+            state.selectedStations = action.payload;
+        },
     },
 });
 
@@ -143,6 +150,7 @@ export const {
     openPaletteAppClip,
     closePaletteAppClip,
     onPaletteAppClipEmit,
+    setSelectedStations,
 } = appSlice.actions;
 
 const appReducer = appSlice.reducer;

--- a/src/redux/param/action.ts
+++ b/src/redux/param/action.ts
@@ -630,3 +630,23 @@ export const autoNumbering = (branchIndex: number, from: number, maxLength = 2, 
         }
     };
 };
+
+export const updateStationsProperty = <K extends keyof StationInfo>(
+    stationIds: string[],
+    key: K,
+    value: StationInfo[K]
+) => {
+    return (dispatch: RootDispatch, getState: () => RootState) => {
+        const { stn_list } = getState().param;
+        const nextStationList = { ...stn_list };
+
+        const uniqueIds = Array.from(new Set(stationIds));
+        uniqueIds.forEach(id => {
+            if (nextStationList[id]) {
+                nextStationList[id] = { ...nextStationList[id], [key]: value };
+            }
+        });
+
+        dispatch(setStationsBulk(nextStationList));
+    };
+};


### PR DESCRIPTION
**描述：**
本 PR 引入了完整的站点批量编辑功能，并重构了底层的字段生成逻辑以提高代码的可维护性。

#### 主要变更

**1. 批量站点编辑**
- **多选支持**：在 `StationAgGrid` 中启用了多行选择功能，按住 `Ctrl` 多选，按住 `Shift` 连续选择。
- **批量编辑面板**：新增 `BatchStationEditPanel`，当选中多个站点时自动显示。
- **批量更新**：用户现在可以同时更新所有选中站点的以下属性：
    - 列车服务（支持基于样式的过滤）
    - 设施图标
    - “单行显示”模式 (SHMetro)
    - 间距调整（Int Padding & Character Spacing）
    - “建设中”状态
    - 删除

**2. 重构：`useStationEditFields` Hook**
- **去重**：将站点属性表单的配置逻辑提取为可复用的 Hook `useStationEditFields`。
- **配置驱动架构**：将服务和设施选项的生成重构为清晰的 **白名单配置模式** (`SERVICE_ALLOW_CONFIG`, `FACILITY_ALLOW_CONFIG`)。
    - *原因*：这使得未来添加新地图风格（如 `BeijingSubway`）或修改现有约束变得非常简单，无需修改核心逻辑代码。
- **逻辑统一**：`MoreSection`（单站编辑）和 `BatchStationEditPanel`（批量编辑）现在共用此 Hook，确保了 UI 行为的一致性并减少了重复代码。

**3. 国际化 (i18n)**
- 为新的批量编辑界面和计数器添加了多语言支持（`en`, `zh-Hans`, `zh-Hant`, `ja`, `ko`）。

#### 技术细节
- **Redux**：新增 `updateStationsProperty` Action 用于批量更新。
- **配置策略**：
    - `SERVICE_ALLOW_CONFIG`：定义每个样式允许的列车服务（默认：普通车/快车/直达车；广州地铁：仅快车/直达车）。
    - `FACILITY_ALLOW_CONFIG`：使用白名单策略定义每个样式允许的设施，显式表达意图。

#### 测试指南
1. 选中单个站点 -> 验证“更多设置”面板功能与之前一致。
2. 按住 `Ctrl` / `Shift` 在表格中选中多个站点。
3. 验证侧边栏切换至“批量编辑”模式。
4. 修改某项属性（如“设施”）-> 验证画布上所有选中站点均同步更新。
5. 点击“删除” -> 验证确认弹窗正常显示且逻辑正确。

#### 其他说明
本功能代码主要由 Gemini 3 Pro 辅助生成。
代码有经过人工审查，经过了简单的测试，确认功能行为符合预期且与现有业务逻辑兼容。
