### PR TITLE
refactor: simplify reverseStations by removing flipBranch and unifying logic

### DIFF
--- a/src/components/side-panel/branch-side-panel/action-section.tsx
+++ b/src/components/side-panel/branch-side-panel/action-section.tsx
@@ -21,7 +21,7 @@ export default function ActionSection() {
     const [isAutoNumModalOpen, setIsAutoNumModalOpen] = useState(false);
 
     const handleReverseStations = () => {
-        dispatch(reverseStations(style === RmgStyle.SHMetro));
+        dispatch(reverseStations());
         rmgRuntime.event(Events.REVERSE_STATIONS, { style });
     };
 

--- a/src/redux/param/action.ts
+++ b/src/redux/param/action.ts
@@ -43,54 +43,29 @@ export const setStationsBulk = (stations: StationDict) => {
 };
 
 /**
- * @param flipBranch Set as false if you want to rotate the line but keeping the topology ordering (TPO). Set as true if you want to flip branches and break the TPO (for SHMetro).
+ * Reverses the direction of the entire line by swapping parents/children
+ * and mirroring branch.left/right for every station.
  */
-export const reverseStations = (flipBranch = false) => {
+export const reverseStations = () => {
     return (dispatch: RootDispatch, getState: () => RootState) => {
         const { stn_list } = getState().param;
-        const newStationList = Object.keys(stn_list).reduce(
-            (acc, stnId) => ({
+        const swapId = (id: string) => (id === 'linestart' ? 'lineend' : id === 'lineend' ? 'linestart' : id);
+
+        const newStationList = Object.keys(stn_list).reduce((acc, stnId) => {
+            const source = stn_list[swapId(stnId)];
+            return {
                 ...acc,
-                [stnId]: (id => {
-                    switch (id) {
-                        case 'linestart':
-                            return {
-                                ...stn_list.lineend,
-                                parents: [],
-                                children: flipBranch ? stn_list.lineend.parents : stn_list.lineend.parents.toReversed(),
-                                branch: { right: stn_list.lineend.branch?.left },
-                            };
-                        case 'lineend':
-                            return {
-                                ...stn_list.linestart,
-                                parents: flipBranch
-                                    ? stn_list.linestart.children
-                                    : stn_list.linestart.children.toReversed(),
-                                children: [],
-                                branch: { left: stn_list.linestart.branch?.right },
-                            };
-                        default: {
-                            const mappedParents = stn_list[id].children.map(id =>
-                                id === 'linestart' ? 'lineend' : id === 'lineend' ? 'linestart' : id
-                            );
-                            const mappedChildren = stn_list[id].parents.map(id =>
-                                id === 'linestart' ? 'lineend' : id === 'lineend' ? 'linestart' : id
-                            );
-                            return {
-                                ...stn_list[id],
-                                parents: flipBranch ? mappedParents : mappedParents.reverse(),
-                                children: flipBranch ? mappedChildren : mappedChildren.reverse(),
-                                branch: {
-                                    left: stn_list[id].branch?.right,
-                                    right: stn_list[id].branch?.left,
-                                },
-                            };
-                        }
-                    }
-                })(stnId),
-            }),
-            {} as StationDict
-        );
+                [stnId]: {
+                    ...source,
+                    parents: source.children.map(swapId),
+                    children: source.parents.map(swapId),
+                    branch: {
+                        left: source.branch?.right,
+                        right: source.branch?.left,
+                    },
+                },
+            };
+        }, {} as StationDict);
         dispatch(setStationsBulk(newStationList));
     };
 };

--- a/src/redux/param/param-slice.test.ts
+++ b/src/redux/param/param-slice.test.ts
@@ -216,7 +216,7 @@ describe('ParamSlice', () => {
             const linestartInfo = updatedStationList.linestart;
             expect(linestartInfo).toBeDefined();
             expect(linestartInfo.parents).toHaveLength(0);
-            expect(linestartInfo.children).toEqual(['stn4', 'stn2']); // reverse lineend's parents
+            expect(linestartInfo.children).toEqual(['stn2', 'stn4']); // lineend's parents, order preserved
             expect(linestartInfo.branch?.left).toBeUndefined();
             expect(linestartInfo.branch?.right).toEqual([BranchStyle.through, 'stn4']); // lineend's left branch
 
@@ -229,15 +229,15 @@ describe('ParamSlice', () => {
 
             const stn1Info = updatedStationList.stn1;
             expect(stn1Info).toBeDefined();
-            expect(stn1Info.parents).toEqual(['stn3', 'stn2']); // reverse self children
-            expect(stn1Info.children).toEqual(['stn0']); // reverse self parent and swap linestart and lineend
+            expect(stn1Info.parents).toEqual(['stn2', 'stn3']); // self children mapped, order preserved
+            expect(stn1Info.children).toEqual(['stn0']);
             expect(stn1Info.branch?.left).toEqual([BranchStyle.through, 'stn3']); // self right branch
             expect(stn1Info.branch?.right).toBeUndefined();
 
             const stn2Info = updatedStationList.stn2;
             expect(stn2Info).toBeDefined();
             expect(stn2Info.parents).toEqual(['linestart']);
-            expect(stn2Info.children).toEqual(['stn1']); // swap parents and children and swap linestart and lineend
+            expect(stn2Info.children).toEqual(['stn1']);
             expect(stn2Info.branch?.left).toBeUndefined();
             expect(stn2Info.branch?.right).toBeUndefined();
 
@@ -263,25 +263,23 @@ describe('ParamSlice', () => {
             expect(lineendInfo.branch?.right).toBeUndefined();
         });
 
-        it('Can flip stations as expected - SHMetro', () => {
-            mockStore.dispatch(reverseStations(true));
+        it('Can reverse stations twice and return to original topology', () => {
+            mockStore.dispatch(reverseStations());
+            mockStore.dispatch(reverseStations());
 
             const updatedStationList = mockStore.getState().param.stn_list;
-            expect(updatedStationList).toBeDefined();
 
-            const linestartInfo = updatedStationList.linestart;
-            expect(linestartInfo).toBeDefined();
-            expect(linestartInfo.parents).toHaveLength(0);
-            expect(linestartInfo.children).toEqual(['stn2', 'stn4']); // lineend's parents not reversed
-            expect(linestartInfo.branch?.left).toBeUndefined();
-            expect(linestartInfo.branch?.right).toEqual([BranchStyle.through, 'stn4']); // lineend's left branch
+            // linestart should be back to original
+            expect(updatedStationList.linestart.children).toEqual(mockSimpleStationList.linestart.children);
 
-            const stn1Info = updatedStationList.stn1;
-            expect(stn1Info).toBeDefined();
-            expect(stn1Info.parents).toEqual(['stn2', 'stn3']); // self children not reversed
-            expect(stn1Info.children).toEqual(['stn0']);
-            expect(stn1Info.branch?.left).toEqual([BranchStyle.through, 'stn3']);
-            expect(stn1Info.branch?.right).toBeUndefined();
+            // stn1 branch node should preserve children order and branch info
+            expect(updatedStationList.stn1.children).toEqual(mockSimpleStationList.stn1.children);
+            expect(updatedStationList.stn1.parents).toEqual(mockSimpleStationList.stn1.parents);
+            expect(updatedStationList.stn1.branch).toEqual(mockSimpleStationList.stn1.branch);
+
+            // lineend should preserve parents order and branch info
+            expect(updatedStationList.lineend.parents).toEqual(mockSimpleStationList.lineend.parents);
+            expect(updatedStationList.lineend.branch).toEqual(mockSimpleStationList.lineend.branch);
         });
     });
 


### PR DESCRIPTION
- Remove flipBranch parameter (array reversal is unnecessary since rendering depends on branch.left/right, not array index order)
- Unify linestart/lineend/default cases into a single swapId-based transform that swaps parents/children and mirrors branch direction
- Update tests: remove SHMetro-specific flip test, add double-reverse idempotency test