### PR TITLE
feat(shmetro-loop): gray out past stations and segments on coline

### DIFF
--- a/src/svgs/shmetro/loop/loop-branches-shmetro.tsx
+++ b/src/svgs/shmetro/loop/loop-branches-shmetro.tsx
@@ -5,6 +5,8 @@ import { StationSHMetro as StationSHMetroIndoor } from '../indoor/station-shmetr
 import React from 'react';
 import { ColourHex } from '@railmapgen/rmg-palette-resources';
 
+type BranchSeg = { d: string; color: string; markerEnd?: string };
+
 export const get_loop_branches = (
     branches: string[][],
     branch_stn_ids: string[],
@@ -45,6 +47,25 @@ export const get_loop_branches = (
     return { loop_branches, line_xs_branches, xs_branches };
 };
 
+/**
+ * Find the nearest loop connection station for a given branch.
+ * In the loop line (Shanghai Metro Lines 3/4), each branch has at most 2 connection stations.
+ */
+export const find_branch_connection = (
+    raw_branch: string[],
+    loopline: string[],
+    branch_stn_ids: string[]
+): { connection_stn: string; connection_is_origin: boolean } | undefined => {
+    const pivot = raw_branch.findIndex(stn => !loopline.includes(stn) && !['linestart', 'lineend'].includes(stn));
+    if (pivot === -1) return undefined;
+    const connection_stn = branch_stn_ids
+        .filter(b => raw_branch.includes(b))
+        .sort((a, b) => Math.abs(raw_branch.indexOf(a) - pivot) - Math.abs(raw_branch.indexOf(b) - pivot))
+        .at(0);
+    if (!connection_stn) return undefined;
+    return { connection_stn, connection_is_origin: raw_branch.indexOf(connection_stn) < pivot };
+};
+
 export const LoopBranches = (props: {
     loop_branches: string[][];
     edges: [number, number, number, number];
@@ -55,88 +76,171 @@ export const LoopBranches = (props: {
         [k: string]: number;
     };
     canvas: CanvasType.RailMap | CanvasType.Indoor;
+    colinePastStationIds?: Set<string>;
 }) => {
-    const { loop_branches, edges, xs, ys, canvas } = props;
+    const { loop_branches, edges, xs, ys, canvas, colinePastStationIds } = props;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [X_LEFT, X_RIGHT, Y_TOP, Y_BOTTOM] = edges;
 
     const { branches } = useRootSelector(store => store.helper);
     const { current_stn_idx: current_stn_id, direction, coline } = useRootSelector(store => store.param);
 
-    const e = canvas === CanvasType.RailMap ? 30 : 0;
-    const branches_paths = [
-        `M ${X_LEFT},${Y_TOP} H ${Number(xs[loop_branches.at(0)?.at(0) ?? '']) - e}`,
-        `M ${X_RIGHT},${Y_TOP} H ${Number(xs[loop_branches.at(1)?.at(-1) ?? '']) + e}`,
-    ];
-
     const loopline = branches[0].filter(stn_id => !['linestart', 'lineend'].includes(stn_id));
+    const branch_stn_ids = branches
+        .slice(0, 3) // drop additional branches
+        .flat()
+        .filter(
+            (
+                o => v =>
+                    (o[v] = (o[v] || 0) + 1) === 2
+            )({} as { [stn_id: string]: number })
+        ) // count each occurrence
+        .filter(stn_id => !['linestart', 'lineend'].includes(stn_id)); // find branch stations
+
+    const get_branch_stn_state = (stn_id: string): -1 | 0 | 1 =>
+        current_stn_id === stn_id ? 0 : colinePastStationIds?.has(stn_id) ? -1 : 1;
+
+    const e = canvas === CanvasType.RailMap ? 30 : 0;
+
     const branches_coline_color = Object.values(coline)
         .filter(co => ![co.from, co.to].every(stn_id => loopline.includes(stn_id)))
         .map(co => co.colors);
 
     return (
         <>
-            {loop_branches.map((loop_branch, i) => (
-                <React.Fragment key={loop_branch.at(0)}>
-                    {branches_coline_color
-                        // remove duplicate
-                        .filter((c, i, self) => i === self.findIndex(t => t.at(0)?.at(2) === c.at(0)?.at(2)))
-                        // generate marker with coline color
-                        .map(color => (
-                            <marker key={color[0][2]} id={`arrow_theme_${color[0][2]}`} refX={1} refY={0.5}>
-                                <path d="M0,1H2L1,0z" fill={color[0][2]} />
-                            </marker>
-                        ))}
-                    <path
-                        stroke={branches_coline_color.at(i)?.at(0)?.at(2) ?? 'var(--rmg-theme-colour)'}
-                        strokeWidth={12}
-                        fill="none"
-                        d={branches_paths[i]}
-                        markerEnd={
-                            canvas === CanvasType.RailMap &&
-                            ((direction === 'l' && i === 0) || (direction === 'r' && i === 1))
-                                ? branches_coline_color.at(i)
-                                    ? `url(#arrow_theme_${branches_coline_color[i][0][2]})`
-                                    : 'url(#arrow_theme)'
-                                : undefined
-                        }
-                    />
-                    {loop_branch
-                        .filter(stn_id => !['linestart', 'lineend'].includes(stn_id))
-                        .map(stn_id => (
-                            <React.Fragment key={stn_id}>
-                                {canvas === CanvasType.RailMap && (
-                                    <g key={stn_id} transform={`translate(${xs[stn_id]},${ys[stn_id]})`}>
-                                        <StationSHMetro
-                                            stnId={stn_id}
-                                            stnState={current_stn_id === stn_id ? 0 : 1}
-                                            bank={0}
-                                            direction={direction}
-                                            color={branches_coline_color.at(i)?.at(0)?.at(2) as ColourHex | undefined}
-                                        />
-                                    </g>
-                                )}
+            {loop_branches.map((loop_branch, i) => {
+                const raw_branch = branches[i + 1];
+                const stns = loop_branch.filter(
+                    stn_id => !['linestart', 'lineend'].includes(stn_id) && !loopline.includes(stn_id)
+                );
+                if (!raw_branch || stns.length === 0) return null;
 
-                                {canvas === CanvasType.Indoor && (
-                                    <g key={stn_id} transform={`translate(${xs[stn_id]},${ys[stn_id]})`}>
-                                        <StationSHMetroIndoor
-                                            stnId={stn_id}
-                                            nameDirection={
-                                                loop_branches
-                                                    .filter(branch => branch.includes(stn_id))
-                                                    .map(branch =>
-                                                        branch.indexOf(stn_id) % 2 === 0 ? 'downward' : 'upward'
-                                                    )[0] as 'upward' | 'downward'
-                                            }
-                                            services={[Services.local]}
-                                            color={branches_coline_color.at(i)?.at(0)?.at(2) as ColourHex | undefined}
-                                        />
-                                    </g>
-                                )}
-                            </React.Fragment>
+                const coline_color: string = branches_coline_color.at(i)?.at(0)?.at(2) ?? 'var(--rmg-theme-colour)';
+
+                const is_gray = (state: -1 | 0 | 1): boolean => canvas !== CanvasType.Indoor && state === -1;
+
+                const conn = find_branch_connection(raw_branch, loopline, branch_stn_ids);
+                const connection_is_origin = conn?.connection_is_origin ?? false;
+
+                const show_arrow =
+                    canvas === CanvasType.RailMap && ((direction === 'l' && i === 0) || (direction === 'r' && i === 1));
+                const arrow_marker_url = (stn: string) =>
+                    get_branch_stn_state(stn) === -1
+                        ? 'url(#arrow_gray)'
+                        : branches_coline_color.at(i)
+                          ? `url(#arrow_theme_${branches_coline_color[i][0][2]})`
+                          : 'url(#arrow_theme)';
+
+                // order stations from edge boundary to arrow tip
+                const ordered_stns = connection_is_origin ? stns : [...stns].reverse();
+                const edge_x = connection_is_origin ? X_RIGHT : X_LEFT;
+                const tip_offset = connection_is_origin ? e : -e;
+                // The edge segment (from SVG boundary to first station) should be gray
+                // when the train is heading towards the boundary (i.e. already passed first station).
+                const edge_gray_dir: 'l' | 'r' = connection_is_origin ? 'r' : 'l';
+                // Inner segments (between stations) should be gray
+                // when the train is heading away from the boundary (i.e. already passed inner stations).
+                const inner_gray_dir: 'l' | 'r' = connection_is_origin ? 'l' : 'r';
+
+                const seg_paths: BranchSeg[] = [];
+
+                const first_stn_state = get_branch_stn_state(ordered_stns[0]);
+                seg_paths.push({
+                    d: `M ${edge_x},${Y_TOP} H ${xs[ordered_stns[0]]}`,
+                    color:
+                        is_gray(first_stn_state) || (direction === edge_gray_dir && first_stn_state === 0)
+                            ? 'var(--rmg-grey)'
+                            : coline_color,
+                });
+
+                for (let j = 0; j < ordered_stns.length - 1; j++) {
+                    const state = get_branch_stn_state(ordered_stns[j]);
+                    seg_paths.push({
+                        d: `M ${xs[ordered_stns[j]]},${Y_TOP} H ${xs[ordered_stns[j + 1]]}`,
+                        color:
+                            is_gray(state) || (direction === inner_gray_dir && state === 0)
+                                ? 'var(--rmg-grey)'
+                                : coline_color,
+                    });
+                }
+
+                const tip_stn = ordered_stns[ordered_stns.length - 1];
+                const tip_state = get_branch_stn_state(tip_stn);
+                seg_paths.push({
+                    d: `M ${xs[tip_stn]},${Y_TOP} H ${xs[tip_stn] + tip_offset}`,
+                    color:
+                        is_gray(tip_state) || (direction === inner_gray_dir && tip_state === 0)
+                            ? 'var(--rmg-grey)'
+                            : coline_color,
+                    markerEnd: show_arrow ? arrow_marker_url(tip_stn) : undefined,
+                });
+
+                return (
+                    <React.Fragment key={loop_branch.at(0)}>
+                        {branches_coline_color
+                            // remove duplicate
+                            .filter((c, ci, self) => ci === self.findIndex(t => t.at(0)?.at(2) === c.at(0)?.at(2)))
+                            // generate marker with coline color
+                            .map(color => (
+                                <marker key={color[0][2]} id={`arrow_theme_${color[0][2]}`} refX={1} refY={0.5}>
+                                    <path d="M0,1H2L1,0z" fill={color[0][2]} />
+                                </marker>
+                            ))}
+                        {seg_paths.map((seg, idx) => (
+                            <path
+                                key={idx}
+                                stroke={seg.color}
+                                strokeWidth={12}
+                                fill="none"
+                                d={seg.d}
+                                markerEnd={seg.markerEnd}
+                            />
                         ))}
-                </React.Fragment>
-            ))}
+                        {stns.map(stn_id => {
+                            const state = get_branch_stn_state(stn_id);
+                            return (
+                                <React.Fragment key={stn_id}>
+                                    {canvas === CanvasType.RailMap && (
+                                        <g transform={`translate(${xs[stn_id]},${ys[stn_id]})`}>
+                                            <StationSHMetro
+                                                stnId={stn_id}
+                                                stnState={state}
+                                                bank={0}
+                                                direction={direction}
+                                                color={
+                                                    state === -1
+                                                        ? undefined
+                                                        : (branches_coline_color.at(i)?.at(0)?.at(2) as
+                                                              | ColourHex
+                                                              | undefined)
+                                                }
+                                            />
+                                        </g>
+                                    )}
+                                    {canvas === CanvasType.Indoor && (
+                                        <g transform={`translate(${xs[stn_id]},${ys[stn_id]})`}>
+                                            <StationSHMetroIndoor
+                                                stnId={stn_id}
+                                                nameDirection={
+                                                    loop_branches
+                                                        .filter(branch => branch.includes(stn_id))
+                                                        .map(branch =>
+                                                            branch.indexOf(stn_id) % 2 === 0 ? 'downward' : 'upward'
+                                                        )[0] as 'upward' | 'downward'
+                                                }
+                                                services={[Services.local]}
+                                                color={
+                                                    branches_coline_color.at(i)?.at(0)?.at(2) as ColourHex | undefined
+                                                }
+                                            />
+                                        </g>
+                                    )}
+                                </React.Fragment>
+                            );
+                        })}
+                    </React.Fragment>
+                );
+            })}
         </>
     );
 };

--- a/src/svgs/shmetro/loop/loop-coline-shmetro.tsx
+++ b/src/svgs/shmetro/loop/loop-coline-shmetro.tsx
@@ -17,11 +17,18 @@ export const LoopColine = (props: {
         [stn_id: string]: number;
     };
     canvas: CanvasType.RailMap | CanvasType.Indoor;
+    colinePastStationIds?: Set<string>;
 }) => {
-    const { edges, loop_stns, xs, ys, canvas } = props;
+    const { edges, loop_stns, xs, ys, canvas, colinePastStationIds } = props;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [X_LEFT, X_RIGHT, Y_TOP, Y_BOTTOM] = edges;
-    const { info_panel_type, stn_list, coline } = useRootSelector(store => store.param);
+    const {
+        info_panel_type,
+        stn_list,
+        coline,
+        current_stn_idx: current_stn_id,
+        direction,
+    } = useRootSelector(store => store.param);
 
     const { branches } = useRootSelector(store => store.helper);
 
@@ -41,43 +48,79 @@ export const LoopColine = (props: {
 
     const LINE_WIDTH = 12;
     const COLINE_GAP = canvas === CanvasType.RailMap && info_panel_type === 'sh2020' ? 3 : 0;
+
+    const coline_segments = [X_LEFT, ...loop_stns.top.map(id => xs[id]), X_RIGHT]
+        .map((x, i, arr) => {
+            if (i === arr.length - 1) return null;
+
+            const prev_id = i === 0 ? null : loop_stns.top[i - 1];
+            const next_id = i === loop_stns.top.length ? null : loop_stns.top[i];
+
+            // Use the station in the travel direction's "behind" side to decide if this segment is past.
+            // For direction 'l' (leftward), the segment after a station is the one to its right (prev_id).
+            // For direction 'r' (rightward), the segment after a station is the one to its left (next_id).
+            const ref_id = direction === 'l' ? prev_id : next_id;
+            // If ref_id is at the edge (null), fall back to the station on the other side of the segment.
+            const fallback_id = direction === 'l' ? next_id : prev_id;
+            const is_past =
+                canvas !== CanvasType.Indoor &&
+                (ref_id
+                    ? (colinePastStationIds?.has(ref_id) ?? false) || ref_id === current_stn_id
+                    : fallback_id
+                      ? (colinePastStationIds?.has(fallback_id) ?? false)
+                      : false);
+
+            return { from: x, to: arr[i + 1], gray: is_past };
+        })
+        .filter(Boolean) as { from: number; to: number; gray: boolean }[];
+
     return (
         <g id="coline_main">
-            <path d={`M ${X_LEFT},${Y_TOP} H${X_RIGHT}`} strokeWidth={12} stroke={coline_main_color?.at(0)?.at(2)} />
+            {coline_segments.map(({ from, to, gray }, j) => (
+                <path
+                    key={j}
+                    d={`M${from},${Y_TOP} H${to}`}
+                    strokeWidth={12}
+                    stroke={gray ? 'var(--rmg-grey)' : coline_main_color?.at(0)?.at(2)}
+                />
+            ))}
             {
                 // additional station cover on the rail map
                 canvas === CanvasType.RailMap &&
                     Object.keys(coline).length > 0 &&
-                    loop_stns.top.map(stn_id => (
-                        <g key={stn_id} transform={`translate(${xs[stn_id]},${ys[stn_id]})`}>
-                            {info_panel_type === 'sh2020' ? (
-                                <>
-                                    <rect
-                                        stroke="none"
-                                        height={24}
-                                        width={12}
-                                        x={-6}
-                                        y={-COLINE_GAP - 1}
-                                        fill={coline_main_color?.at(0)?.at(2)}
+                    loop_stns.top.map(stn_id => {
+                        const is_stn_past = colinePastStationIds?.has(stn_id) ?? false;
+                        return (
+                            <g key={stn_id} transform={`translate(${xs[stn_id]},${ys[stn_id]})`}>
+                                {info_panel_type === 'sh2020' ? (
+                                    <>
+                                        <rect
+                                            stroke="none"
+                                            height={24}
+                                            width={12}
+                                            x={-6}
+                                            y={-COLINE_GAP - 1}
+                                            fill={is_stn_past ? 'var(--rmg-grey)' : coline_main_color?.at(0)?.at(2)}
+                                        />
+                                        <rect
+                                            stroke="none"
+                                            height={COLINE_GAP + LINE_WIDTH}
+                                            width={12}
+                                            x={-6}
+                                            y={LINE_WIDTH - 2}
+                                            fill={is_stn_past ? 'var(--rmg-grey)' : 'var(--rmg-theme-colour)'}
+                                        />
+                                    </>
+                                ) : (
+                                    <use
+                                        xlinkHref="#int2_sh"
+                                        stroke={is_stn_past ? 'var(--rmg-grey)' : 'var(--rmg-theme-colour)'}
+                                        transform={`translate(0,${1 + LINE_WIDTH})`}
                                     />
-                                    <rect
-                                        stroke="none"
-                                        height={COLINE_GAP + LINE_WIDTH}
-                                        width={12}
-                                        x={-6}
-                                        y={LINE_WIDTH - 2}
-                                        fill="var(--rmg-theme-colour)"
-                                    />
-                                </>
-                            ) : (
-                                <use
-                                    xlinkHref="#int2_sh"
-                                    stroke="var(--rmg-theme-colour)"
-                                    transform={`translate(0,${1 + LINE_WIDTH})`}
-                                />
-                            )}
-                        </g>
-                    ))
+                                )}
+                            </g>
+                        );
+                    })
             }
         </g>
     );

--- a/src/svgs/shmetro/loop/loop-shmetro.test.ts
+++ b/src/svgs/shmetro/loop/loop-shmetro.test.ts
@@ -1,0 +1,125 @@
+import { ColineInfo, ShortDirection } from '../../../constants/constants';
+import { find_branch_connection } from './loop-branches-shmetro';
+import { get_coline_arc_stations, get_branch_past_stations } from './loop-shmetro';
+
+describe('find_branch_connection', () => {
+    const loopline = ['s1', 's2', 's3', 's4'];
+
+    it('returns the nearest connection station on the origin side', () => {
+        const raw_branch = ['linestart', 's1', 'b1', 'b2', 's3', 'lineend'];
+        const result = find_branch_connection(raw_branch, loopline, ['s1', 's3']);
+        expect(result).toEqual({ connection_stn: 's1', connection_is_origin: true });
+    });
+
+    it('returns the nearest connection station on the non-origin side', () => {
+        const raw_branch = ['linestart', 's3', 'b1', 'b2', 's1', 'lineend'];
+        const result = find_branch_connection(raw_branch, loopline, ['s1', 's3']);
+        expect(result).toEqual({ connection_stn: 's3', connection_is_origin: true });
+    });
+
+    it('returns undefined when branch has no non-loop stations', () => {
+        const raw_branch = ['linestart', 's1', 's2', 's3', 'lineend'];
+        const result = find_branch_connection(raw_branch, loopline, ['s1', 's3']);
+        expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when no branch station ids match', () => {
+        const raw_branch = ['linestart', 'b1', 'b2', 'lineend'];
+        const result = find_branch_connection(raw_branch, loopline, ['s1', 's3']);
+        expect(result).toBeUndefined();
+    });
+
+    it('handles empty raw_branch', () => {
+        const result = find_branch_connection([], loopline, ['s1']);
+        expect(result).toBeUndefined();
+    });
+});
+
+describe('get_coline_arc_stations', () => {
+    const loopline = ['s1', 's2', 's3', 's4', 's5', 's6'];
+
+    const makeColine = (from: string, to: string, display = true): Record<string, ColineInfo> => ({
+        co1: { from, to, display, colors: [] },
+    });
+
+    it('returns stations on the shorter arc between from and to', () => {
+        const result = get_coline_arc_stations(loopline, makeColine('s2', 's4'));
+        expect(result).toEqual(new Set(['s2', 's3', 's4']));
+    });
+
+    it('wraps around the loop for the shorter arc', () => {
+        const result = get_coline_arc_stations(loopline, makeColine('s5', 's1'));
+        expect(result).toEqual(new Set(['s5', 's6', 's1']));
+    });
+
+    it('returns empty set when coline display is false', () => {
+        const result = get_coline_arc_stations(loopline, makeColine('s1', 's3', false));
+        expect(result).toEqual(new Set());
+    });
+
+    it('returns empty set when from or to not in loopline', () => {
+        const result = get_coline_arc_stations(loopline, makeColine('s1', 'unknown'));
+        expect(result).toEqual(new Set());
+    });
+
+    it('returns empty set for empty coline', () => {
+        const result = get_coline_arc_stations(loopline, {});
+        expect(result).toEqual(new Set());
+    });
+
+    it('returns empty set for empty loopline', () => {
+        const result = get_coline_arc_stations([], makeColine('s1', 's3'));
+        expect(result).toEqual(new Set());
+    });
+});
+
+describe('get_branch_past_stations', () => {
+    const loopline = ['s1', 's2', 's3', 's4'];
+
+    it('marks branch stations past when connection station is past', () => {
+        const branches = [
+            ['linestart', 's1', 's2', 's3', 's4', 'lineend'],
+            ['linestart', 's1', 'b1', 'b2', 's3', 'lineend'],
+        ];
+        const loop_past = new Set(['s1']);
+        const result = get_branch_past_stations(branches, loopline, 's2', ShortDirection.left, ['s1', 's3'], loop_past);
+        expect(result).toContain('b1');
+        expect(result).toContain('b2');
+    });
+
+    it('marks stations past by direction when current is on branch (direction l)', () => {
+        const branches = [
+            ['linestart', 's1', 's2', 's3', 's4', 'lineend'],
+            ['linestart', 's1', 'b1', 'b2', 'b3', 's3', 'lineend'],
+        ];
+        const result = get_branch_past_stations(branches, loopline, 'b2', ShortDirection.left, ['s1', 's3'], new Set());
+        expect(result).toContain('b3');
+        expect(result).not.toContain('b1');
+    });
+
+    it('marks stations past by direction when current is on branch (direction r)', () => {
+        const branches = [
+            ['linestart', 's1', 's2', 's3', 's4', 'lineend'],
+            ['linestart', 's1', 'b1', 'b2', 'b3', 's3', 'lineend'],
+        ];
+        const result = get_branch_past_stations(
+            branches,
+            loopline,
+            'b2',
+            ShortDirection.right,
+            ['s1', 's3'],
+            new Set()
+        );
+        expect(result).toContain('b1');
+        expect(result).not.toContain('b3');
+    });
+
+    it('does nothing when branch has no non-loop stations', () => {
+        const branches = [
+            ['linestart', 's1', 's2', 's3', 's4', 'lineend'],
+            ['linestart', 's1', 's2', 'lineend'],
+        ];
+        const result = get_branch_past_stations(branches, loopline, 's2', ShortDirection.left, ['s1'], new Set());
+        expect(result).toHaveLength(0);
+    });
+});

--- a/src/svgs/shmetro/loop/loop-shmetro.tsx
+++ b/src/svgs/shmetro/loop/loop-shmetro.tsx
@@ -1,7 +1,7 @@
 /* eslint @typescript-eslint/no-non-null-assertion: 0 */
 import StationSHMetro from '../station-shmetro';
 import { NameDirection, StationSHMetro as StationSHMetroIndoor } from '../indoor/station-shmetro';
-import { CanvasType, Services, ShortDirection } from '../../../constants/constants';
+import { CanvasType, ColineInfo, Services, ShortDirection, StationDict } from '../../../constants/constants';
 import { useRootSelector } from '../../../redux';
 import { isColineBranch } from '../../../redux/param/coline-action';
 import {
@@ -11,8 +11,136 @@ import {
     split_loop_stns_with_branch,
     split_loop_stns_with_branches,
 } from '../../methods/shmetro-loop';
-import { get_loop_branches, LoopBranches } from './loop-branches-shmetro';
+import { find_branch_connection, get_loop_branches, LoopBranches } from './loop-branches-shmetro';
 import { LoopColine } from './loop-coline-shmetro';
+
+/**
+ * Get the set of stations on the shorter arc of the displayed coline.
+ * Only one coline in loop line is supported (Shanghai Metro Lines 3/4).
+ *
+ * @param loopline The loop line aka branches[0].
+ * @param coline The coline record from param.
+ * @returns Set of station ids on the shorter arc, or empty set if no coline is displayed.
+ */
+export const get_coline_arc_stations = (loopline: string[], coline: Record<string, ColineInfo>): Set<string> => {
+    const co = Object.values(coline).find(co => co.display);
+    if (!co) return new Set();
+    const n = loopline.length;
+    const from_idx = loopline.indexOf(co.from);
+    const to_idx = loopline.indexOf(co.to);
+    if (from_idx === -1 || to_idx === -1) return new Set();
+    const len = Math.min((to_idx - from_idx + n) % n, (from_idx - to_idx + n) % n);
+    const step = (to_idx - from_idx + n) % n <= (from_idx - to_idx + n) % n ? 1 : -1;
+    return new Set(Array.from({ length: len + 1 }, (_, i) => loopline[(from_idx + step * i + n) % n]));
+};
+
+/**
+ * Get the list of branch stations that are past (already visited) based on the current station and direction.
+ *
+ * @param branches All branches including the loop line.
+ * @param loopline The loop line aka branches[0].
+ * @param current_stn_id Current station id.
+ * @param direction Current travel direction.
+ * @param branch_stn_ids Station ids that appear in multiple branches (connection stations).
+ * @param loop_past Set of loop stations already marked as past.
+ * @returns Array of past branch station ids.
+ */
+export const get_branch_past_stations = (
+    branches: string[][],
+    loopline: string[],
+    current_stn_id: string,
+    direction: ShortDirection,
+    branch_stn_ids: string[],
+    loop_past: Set<string>
+): string[] => {
+    const result: string[] = [];
+    branches.slice(1, 3).forEach(raw_branch => {
+        const branch_stns = raw_branch.filter(
+            stn => !loopline.includes(stn) && !['linestart', 'lineend'].includes(stn)
+        );
+        if (branch_stns.length === 0) return;
+
+        if (raw_branch.includes(current_stn_id)) {
+            const cur_branch_idx = raw_branch.indexOf(current_stn_id);
+            branch_stns.forEach(stn => {
+                const stn_branch_idx = raw_branch.indexOf(stn);
+                if (direction === 'l' ? stn_branch_idx > cur_branch_idx : stn_branch_idx < cur_branch_idx) {
+                    result.push(stn);
+                }
+            });
+        } else {
+            const conn = find_branch_connection(raw_branch, loopline, branch_stn_ids);
+            if (conn && loop_past.has(conn.connection_stn)) {
+                result.push(...branch_stns);
+            }
+        }
+    });
+    return result;
+};
+
+/**
+ * Calculate the set of station ids that should be displayed as past (gray) on the coline.
+ * Includes both loop arc stations and branch stations.
+ *
+ * @param loopline The loop line aka branches[0].
+ * @param coline The coline record from param.
+ * @param branches All branches including the loop line.
+ * @param current_stn_id Current station id.
+ * @param direction Current travel direction.
+ * @param stn_list Station dictionary, used to check if a branch is a coline branch.
+ * @param branch_stn_ids Station ids that appear in multiple branches (connection stations).
+ * @returns Set of station ids that are past.
+ */
+export const get_coline_past_station_ids = (
+    loopline: string[],
+    coline: Record<string, ColineInfo>,
+    branches: string[][],
+    current_stn_id: string,
+    direction: ShortDirection,
+    stn_list: StationDict,
+    branch_stn_ids: string[]
+): Set<string> => {
+    const past = new Set<string>();
+    if (Object.keys(coline).length === 0) return past;
+
+    const coline_arc_stations = get_coline_arc_stations(loopline, coline);
+    const n = loopline.length;
+
+    const active_branch = branches.slice(1, 3).find(branch => branch.includes(current_stn_id));
+    const is_on_coline_branch =
+        active_branch && isColineBranch(active_branch, stn_list) && !loopline.includes(current_stn_id);
+
+    if (!is_on_coline_branch && !coline_arc_stations.has(current_stn_id)) return past;
+
+    const cur_idx = loopline.indexOf(current_stn_id);
+    const conn =
+        cur_idx === -1 && active_branch ? find_branch_connection(active_branch, loopline, branch_stn_ids) : undefined;
+
+    const effective_cur_idx = conn ? loopline.indexOf(conn.connection_stn) : cur_idx;
+    if (effective_cur_idx === -1) return past;
+
+    // Mark loop arc stations that are behind the current station in the travel direction
+    coline_arc_stations.forEach(arc_stn => {
+        const idx = loopline.indexOf(arc_stn);
+        if (idx === effective_cur_idx) return;
+        const past_dist = direction === 'l' ? (idx - effective_cur_idx + n) % n : (effective_cur_idx - idx + n) % n;
+        if (past_dist > 0 && past_dist <= Math.floor(n / 2)) past.add(arc_stn);
+    });
+
+    // If current station is on a branch, also mark its connection station as past when appropriate
+    if (
+        conn &&
+        ((!conn.connection_is_origin && direction === 'l') || (conn.connection_is_origin && direction === 'r'))
+    ) {
+        past.add(conn.connection_stn);
+    }
+
+    // Mark branch stations that are past
+    for (const stn of get_branch_past_stations(branches, loopline, current_stn_id, direction, branch_stn_ids, past)) {
+        past.add(stn);
+    }
+    return past;
+};
 
 const LoopSHMetro = (props: { bank_angle: boolean; canvas: CanvasType.RailMap | CanvasType.Indoor }) => {
     const { bank_angle, canvas } = props;
@@ -127,6 +255,16 @@ const LoopSHMetro = (props: { bank_angle: boolean; canvas: CanvasType.RailMap | 
 
     const xs = { ...xs_branches, ...xs_loop };
 
+    const coline_past_station_ids = get_coline_past_station_ids(
+        loopline,
+        coline,
+        branches,
+        current_stn_id,
+        direction,
+        stn_list,
+        branch_stn_ids
+    );
+
     // generate loop path used in svg
     const path = _linePath(loop_stns, xs, ys, bank, [...line_xs, ...line_ys], direction);
 
@@ -147,7 +285,13 @@ const LoopSHMetro = (props: { bank_angle: boolean; canvas: CanvasType.RailMap | 
             <path stroke="var(--rmg-theme-colour)" strokeWidth={12} fill="none" d={path} strokeLinejoin="round" />
             {/* Order matters. The LoopColine should cover the station in RailMap. */}
             {canvas === CanvasType.RailMap && (
-                <LoopStationGroup canvas={canvas} loop_stns={loop_stns} xs={xs} ys={ys} />
+                <LoopStationGroup
+                    canvas={canvas}
+                    loop_stns={loop_stns}
+                    xs={xs}
+                    ys={ys}
+                    colinePastStationIds={coline_past_station_ids}
+                />
             )}
             <g transform={`translate(0,${Object.keys(coline).length > 0 ? -LINE_WIDTH - COLINE_GAP : 0})`}>
                 <LoopBranches
@@ -156,6 +300,7 @@ const LoopSHMetro = (props: { bank_angle: boolean; canvas: CanvasType.RailMap | 
                     xs={xs}
                     ys={ys}
                     canvas={canvas}
+                    colinePastStationIds={coline_past_station_ids}
                 />
                 {Object.keys(coline).length > 0 && (
                     <LoopColine
@@ -164,11 +309,20 @@ const LoopSHMetro = (props: { bank_angle: boolean; canvas: CanvasType.RailMap | 
                         xs={xs}
                         ys={ys}
                         canvas={canvas}
+                        colinePastStationIds={coline_past_station_ids}
                     />
                 )}
             </g>
             {/* Order matters. The station should cover LoopColine's main path in Indoor. */}
-            {canvas === CanvasType.Indoor && <LoopStationGroup canvas={canvas} loop_stns={loop_stns} xs={xs} ys={ys} />}
+            {canvas === CanvasType.Indoor && (
+                <LoopStationGroup
+                    canvas={canvas}
+                    loop_stns={loop_stns}
+                    xs={xs}
+                    ys={ys}
+                    colinePastStationIds={coline_past_station_ids}
+                />
+            )}
         </g>
     );
 };
@@ -243,9 +397,13 @@ const LoopStationGroup = (props: {
     ys: {
         [k: string]: number;
     };
+    colinePastStationIds?: Set<string>;
 }) => {
-    const { canvas, loop_stns, xs, ys } = props;
+    const { canvas, loop_stns, xs, ys, colinePastStationIds } = props;
     const { current_stn_idx: current_stn_id, stn_list } = useRootSelector(store => store.param);
+
+    const getStnState = (stn_id: string): -1 | 0 | 1 =>
+        current_stn_id === stn_id ? 0 : colinePastStationIds?.has(stn_id) ? -1 : 1;
 
     const railmap_bank: Record<keyof LoopStns, -1 | 0 | 1> = {
         top: 0,
@@ -276,7 +434,7 @@ const LoopStationGroup = (props: {
                             <g key={stn_id} transform={`translate(${xs[stn_id]},${ys[stn_id]})`}>
                                 <StationSHMetro
                                     stnId={stn_id}
-                                    stnState={current_stn_id === stn_id ? 0 : 1}
+                                    stnState={getStnState(stn_id)}
                                     bank={railmap_bank[side as keyof LoopStns]}
                                     direction={railmap_direction[side as keyof LoopStns]}
                                 />


### PR DESCRIPTION
## 描述
现在共线环线也支持过站灰色

## 主要更改
- Add helper functions to determine past stations on the coline arc: get_coline_arc_stations, get_coline_past_station_ids, get_branch_past_stations, find_branch_connection
- Render past coline segments in gray (var(--rmg-grey)) based on current station and travel direction
- Gray out past branch segments and their arrow markers
- Update LoopStationGroup to pass stnState=-1 for past stations
- Add unit tests for loop past station logic

## 其他说明
本功能代码主要由 Claude Sonnet 4.6/Opus 4.6 辅助生成。
经过人工审查与初步的测试，确认功能行为符合预期且与现有业务逻辑兼容。