### PR TITLE
Feat/shmetro 2024 indoor loop

### DIFF
--- a/src/svgs/shmetro/indoor/station-shmetro.tsx
+++ b/src/svgs/shmetro/indoor/station-shmetro.tsx
@@ -20,10 +20,11 @@ interface Props {
     nameDirection: NameDirection;
     services: Services[];
     color?: ColourHex; // Control the station color if coline is in effect.
+    intBoxDirection?: NameDirection; // When set, place IntBoxGroup2024 on this side instead of nameDirection side.
 }
 
 export const StationSHMetro = (props: Props) => {
-    const { stnId, nameDirection, services, color } = props;
+    const { stnId, nameDirection, services, color, intBoxDirection } = props;
     const { stn_list, info_panel_type } = useRootSelector(store => store.param);
     const stnInfo = stn_list[stnId];
 
@@ -36,11 +37,11 @@ export const StationSHMetro = (props: Props) => {
             ...(stnInfo.transfer.groups.at(2)?.lines || []),
         ].length;
 
-        stationIconColor.stroke = 'var(--rmg-theme-colour)';
+        stationIconColor.stroke = color ?? 'var(--rmg-theme-colour)';
         if (stnInfo.services.length === 3) {
-            stationIconStyle = 'stn_sh_2020_direct';
+            stationIconStyle = 'direct_indoor_sh';
         } else if (stnInfo.services.length === 2) {
-            stationIconStyle = 'stn_sh_2020_express';
+            stationIconStyle = 'express_indoor_sh';
         } else if (osi_osysi_length > 1) {
             // 不管多少条站内换乘，只要有超过1个的出站换乘就是3个圆了
             stationIconStyle = 'stn_sh_2024_osysi3';
@@ -56,7 +57,7 @@ export const StationSHMetro = (props: Props) => {
         } else {
             stationIconStyle = 'stn_sh_2024';
             delete stationIconColor.stroke;
-            stationIconColor.fill = 'var(--rmg-theme-colour)';
+            stationIconColor.fill = color ?? 'var(--rmg-theme-colour)';
         }
     } else {
         const non_osysi_transfer = [
@@ -72,7 +73,14 @@ export const StationSHMetro = (props: Props) => {
             non_osysi_transfer.length > 0 ? 'var(--rmg-black)' : (color ?? 'var(--rmg-theme-colour)');
     }
 
-    const dr = nameDirection === 'left' || nameDirection === 'right' ? 90 : 0;
+    const dr =
+        nameDirection === 'left' || nameDirection === 'right'
+            ? info_panel_type === PanelTypeShmetro.sh2024
+                ? nameDirection === 'left'
+                    ? -90
+                    : 90
+                : 90
+            : 0;
     return (
         <>
             <StationNameGElement
@@ -80,6 +88,7 @@ export const StationSHMetro = (props: Props) => {
                 groups={stnInfo.transfer.groups}
                 nameDirection={nameDirection}
                 services={services}
+                intBoxDirection={intBoxDirection}
             />
             <use
                 xlinkHref={`#${stationIconStyle}`}
@@ -122,10 +131,11 @@ interface StationNameGElementProps {
     groups: InterchangeGroup[];
     nameDirection: NameDirection;
     services: Services[];
+    intBoxDirection?: NameDirection;
 }
 
 const StationNameGElement = (props: StationNameGElementProps) => {
-    const { name, groups, nameDirection, services } = props;
+    const { name, groups, nameDirection, services, intBoxDirection } = props;
     const { en: enName = '' } = name;
     const nameENLn = enName.split('\\').length;
     const { info_panel_type } = useRootSelector(store => store.param);
@@ -189,9 +199,26 @@ const StationNameGElement = (props: StationNameGElementProps) => {
             stationNameDY(info_panel_type, nameDirection, nameENLn) -
             STATION_NAME_2024_ZH_FONT_SIZE / 2 -
             INT_BOX_SIZE.height / 2,
-        left: 7,
-        right: 7,
+        left: 12,
+        right: 12,
     };
+    // When intBoxDirection is set, place int boxes on that side instead of the nameDirection side.
+    const dyByDir: Record<NameDirection, number> = { upward: 60, downward: -30, left: 0, right: 0 };
+    const effectiveIntBoxDir = intBoxDirection ?? nameDirection;
+    const intBoxDYCompensation = intBoxDirection ? dyByDir[intBoxDirection] - dy : 0;
+    // stn_sh_2024 icon edges: y=-18 (top) .. 6 (bottom). IntBoxGroup2024 dy = box bottom edge.
+    const intBoxGap = 5;
+    const effectiveIntBoxDY = (() => {
+        if (!intBoxDirection) return intBoxGroup2024DY[nameDirection];
+        if (intBoxDirection === 'upward' || intBoxDirection === 'downward') {
+            const undoParent = -dy;
+            const iconEdge = intBoxDirection === 'upward' ? 6 : -18;
+            return intBoxDirection === 'upward'
+                ? undoParent + iconEdge + intBoxGap + INT_BOX_SIZE.height
+                : undoParent + iconEdge - intBoxGap;
+        }
+        return intBoxGroup2024DY[intBoxDirection] + intBoxDYCompensation;
+    })();
 
     return (
         <g transform={`translate(0,${dy})`}>
@@ -219,22 +246,27 @@ const StationNameGElement = (props: StationNameGElementProps) => {
                 </>
             ) : (
                 <>
-                    {info_panel_type !== PanelTypeShmetro.sh2024 && (
-                        <line
-                            x1={nameDirection === 'left' ? -50 : 15}
-                            x2={nameDirection === 'left' ? -15 : 50}
-                            y1={0}
-                            y2={0}
-                            stroke="black"
-                        />
+                    {info_panel_type !== PanelTypeShmetro.sh2024 ? (
+                        <>
+                            <line
+                                x1={nameDirection === 'left' ? -50 : 15}
+                                x2={nameDirection === 'left' ? -15 : 50}
+                                y1={0}
+                                y2={0}
+                                stroke="black"
+                            />
+                            <line
+                                x1={nameDirection === 'left' ? -50 : 50}
+                                x2={nameDirection === 'left' ? -50 : 50}
+                                y1={-30}
+                                y2={30}
+                                stroke="black"
+                            />
+                        </>
+                    ) : (
+                        /* sh2024: horizontal lead going outward from station icon to name position */
+                        <line x1={0} x2={nameDirection === 'left' ? -60 : 60} y1={0} y2={0} stroke="black" />
                     )}
-                    <line
-                        x1={nameDirection === 'left' ? -50 : 50}
-                        x2={nameDirection === 'left' ? -50 : 50}
-                        y1={-30}
-                        y2={30}
-                        stroke="black"
-                    />
                 </>
             )}
 
@@ -246,8 +278,21 @@ const StationNameGElement = (props: StationNameGElementProps) => {
                         services={services}
                     />
                 )
+            ) : effectiveIntBoxDir === 'left' || effectiveIntBoxDir === 'right' ? (
+                // For side stations, place int boxes on the effectiveIntBoxDir side.
+                <g
+                    transform={`translate(${
+                        effectiveIntBoxDir === 'left' ? nameSize.x - 10 : nameSize.x + nameSize.width + 10
+                    },${intBoxDYCompensation})`}
+                >
+                    <IntBoxGroup2024
+                        groups={groups}
+                        dy={intBoxGroup2024DY[effectiveIntBoxDir]}
+                        align={effectiveIntBoxDir === 'left' ? 'end' : 'start'}
+                    />
+                </g>
             ) : (
-                <IntBoxGroup2024 groups={groups} dy={intBoxGroup2024DY[nameDirection]} />
+                <IntBoxGroup2024 groups={groups} dy={effectiveIntBoxDY} />
             )}
 
             <StationName ref={nameRef} stnName={name} nameDirection={nameDirection} fill="black" />
@@ -447,15 +492,16 @@ const IntBoxGroup = (props: IntBoxGroupProps & SVGProps<SVGGElement>) => {
 };
 
 const IntBoxGroup2024 = forwardRef(function IntBoxGroup2024(
-    props: { groups: InterchangeGroup[]; dy: number },
+    props: { groups: InterchangeGroup[]; dy: number; align?: 'start' | 'center' | 'end' },
     ref: Ref<SVGGElement>
 ) {
-    const { groups, dy } = props;
+    const { groups, dy, align = 'center' } = props;
     const directionPolarity = 1;
 
     const transfer = [groups.at(0)?.lines ?? [], groups.at(1)?.lines ?? [], groups.at(2)?.lines ?? []];
 
-    const [outOfSystemLine, setOutOfSystemLine] = useState(0); // also for start point of 出站换乘
+    const [outOfSystemLine, setOutOfSystemLine] = useState(0); // also for start point of 出站换乘 (groups[1])
+    const [outOfSystemLine2, setOutOfSystemLine2] = useState(0); // for start point of 出站换乘 (groups[2])
     const [intBoxesDX, setIntBoxesDX] = useState<{ [k in string]: number }>({});
     const textLineRefs = useRef<{ [k in string]: SVGGElement }>({});
     const [intBoxGroupWidth, setIntBoxGroupWidth] = useState(0);
@@ -506,11 +552,25 @@ const IntBoxGroup2024 = forwardRef(function IntBoxGroup2024(
                 dx += getBBoxWidth(info);
             });
         }
-        transfer[2].forEach(info => {
-            dx += getBBoxWidth(info);
-        });
+        let outOfSystemLine2 = 0;
+        if (transfer[2].length) {
+            const elementWidth = INT_BOX_SIZE.height;
+            const hasPrevious = transfer[0].length > 0 || transfer[1].length > 0;
+            if (hasPrevious) {
+                outOfSystemLine2 = dx + INT_BOX_SIZE.padding;
+                dx += elementWidth + 2 * INT_BOX_SIZE.padding;
+            } else {
+                dx += INT_BOX_SIZE.padding;
+                outOfSystemLine2 = 0;
+                dx += elementWidth;
+            }
+            transfer[2].forEach(info => {
+                dx += getBBoxWidth(info);
+            });
+        }
         setIntBoxesDX(intBoxDX);
         setOutOfSystemLine(outOfStationLine);
+        setOutOfSystemLine2(outOfSystemLine2);
         setIntBoxGroupWidth(dx);
     }, [JSON.stringify(transfer)]);
 
@@ -541,7 +601,14 @@ const IntBoxGroup2024 = forwardRef(function IntBoxGroup2024(
         );
     };
 
-    const dx = onlyOneNonOutOfStationTextInt ? 0 : -intBoxGroupWidth / 2;
+    const dx =
+        align === 'end'
+            ? -intBoxGroupWidth // right-align: all boxes end at the origin (outer side for left stations)
+            : align === 'start'
+              ? 0 // left-align: all boxes start at the origin (outer side for right stations)
+              : onlyOneNonOutOfStationTextInt
+                ? 0
+                : -intBoxGroupWidth / 2; // center (default)
     return (
         <g ref={ref} fontSize={30} textAnchor="middle" transform={`translate(${dx},${dy})`}>
             {transfer[0].map(makeBoxElement)}
@@ -569,7 +636,30 @@ const IntBoxGroup2024 = forwardRef(function IntBoxGroup2024(
                     {transfer[1].map(makeBoxElement)}
                 </>
             )}
-            {transfer[2].map(makeBoxElement)}
+            {transfer[2].length > 0 && (
+                <>
+                    {(transfer[0].length > 0 || transfer[1].length > 0) && (
+                        <line
+                            y1={-INT_BOX_SIZE.height}
+                            y2={0}
+                            x1={outOfSystemLine2 - 2}
+                            x2={outOfSystemLine2 - 2}
+                            stroke="var(--rmg-black)"
+                        />
+                    )}
+                    <g
+                        transform={`translate(${outOfSystemLine2},-13.5)`}
+                        fill="var(--rmg-black)"
+                        fontSize="15"
+                        textAnchor="start"
+                        className="rmg-name__zh"
+                    >
+                        <text dy="-4">出站</text>
+                        <text dy="11">换乘</text>
+                    </g>
+                    {transfer[2].map(makeBoxElement)}
+                </>
+            )}
         </g>
     );
 });

--- a/src/svgs/shmetro/indoor/station-shmetro.tsx
+++ b/src/svgs/shmetro/indoor/station-shmetro.tsx
@@ -15,16 +15,23 @@ import { useRootSelector } from '../../../redux';
  */
 export type NameDirection = 'upward' | 'downward' | 'left' | 'right';
 
+const oppositeNameDirection: Record<NameDirection, NameDirection> = {
+    upward: 'downward',
+    downward: 'upward',
+    left: 'right',
+    right: 'left',
+};
+
 interface Props {
     stnId: string;
     nameDirection: NameDirection;
     services: Services[];
     color?: ColourHex; // Control the station color if coline is in effect.
-    intBoxDirection?: NameDirection; // When set, place IntBoxGroup2024 on this side instead of nameDirection side.
+    isSh2024IndoorLoop?: boolean;
 }
 
 export const StationSHMetro = (props: Props) => {
-    const { stnId, nameDirection, services, color, intBoxDirection } = props;
+    const { stnId, nameDirection, services, color, isSh2024IndoorLoop = false } = props;
     const { stn_list, info_panel_type } = useRootSelector(store => store.param);
     const stnInfo = stn_list[stnId];
 
@@ -88,7 +95,7 @@ export const StationSHMetro = (props: Props) => {
                 groups={stnInfo.transfer.groups}
                 nameDirection={nameDirection}
                 services={services}
-                intBoxDirection={intBoxDirection}
+                isSh2024IndoorLoop={isSh2024IndoorLoop}
             />
             <use
                 xlinkHref={`#${stationIconStyle}`}
@@ -131,11 +138,11 @@ interface StationNameGElementProps {
     groups: InterchangeGroup[];
     nameDirection: NameDirection;
     services: Services[];
-    intBoxDirection?: NameDirection;
+    isSh2024IndoorLoop?: boolean;
 }
 
 const StationNameGElement = (props: StationNameGElementProps) => {
-    const { name, groups, nameDirection, services, intBoxDirection } = props;
+    const { name, groups, nameDirection, services, isSh2024IndoorLoop = false } = props;
     const { en: enName = '' } = name;
     const nameENLn = enName.split('\\').length;
     const { info_panel_type } = useRootSelector(store => store.param);
@@ -188,6 +195,7 @@ const StationNameGElement = (props: StationNameGElementProps) => {
     }, [name.zh, name.en]);
 
     const panel_type = info_panel_type as PanelTypeShmetro;
+    const isSh2024 = info_panel_type === PanelTypeShmetro.sh2024;
     const verticalLineY = {
         [PanelTypeShmetro.sh2024]: { upward: -15, downward: -30 },
         [PanelTypeShmetro.sh2020]: { upward: -23, downward: -10 },
@@ -202,102 +210,102 @@ const StationNameGElement = (props: StationNameGElementProps) => {
         left: 12,
         right: 12,
     };
-    // When intBoxDirection is set, place int boxes on that side instead of the nameDirection side.
     const dyByDir: Record<NameDirection, number> = { upward: 60, downward: -30, left: 0, right: 0 };
-    const effectiveIntBoxDir = intBoxDirection ?? nameDirection;
-    const intBoxDYCompensation = intBoxDirection ? dyByDir[intBoxDirection] - dy : 0;
+    const effectiveIntBoxDir = isSh2024IndoorLoop ? oppositeNameDirection[nameDirection] : nameDirection;
+    const intBoxDYCompensation = isSh2024IndoorLoop ? dyByDir[effectiveIntBoxDir] - dy : 0;
     // stn_sh_2024 icon edges: y=-18 (top) .. 6 (bottom). IntBoxGroup2024 dy = box bottom edge.
     const intBoxGap = 5;
     const effectiveIntBoxDY = (() => {
-        if (!intBoxDirection) return intBoxGroup2024DY[nameDirection];
-        if (intBoxDirection === 'upward' || intBoxDirection === 'downward') {
+        if (!isSh2024IndoorLoop) return intBoxGroup2024DY[nameDirection];
+        if (effectiveIntBoxDir === 'upward' || effectiveIntBoxDir === 'downward') {
             const undoParent = -dy;
-            const iconEdge = intBoxDirection === 'upward' ? 6 : -18;
-            return intBoxDirection === 'upward'
+            const iconEdge = effectiveIntBoxDir === 'upward' ? 6 : -18;
+            return effectiveIntBoxDir === 'upward'
                 ? undoParent + iconEdge + intBoxGap + INT_BOX_SIZE.height
                 : undoParent + iconEdge - intBoxGap;
         }
-        return intBoxGroup2024DY[intBoxDirection] + intBoxDYCompensation;
+        return intBoxGroup2024DY[effectiveIntBoxDir] + intBoxDYCompensation;
     })();
+
+    if (isSh2024) {
+        return (
+            <g transform={`translate(0,${dy})`}>
+                {nameDirection === 'upward' || nameDirection === 'downward' ? (
+                    <line
+                        y1={verticalLineY[panel_type][nameDirection]}
+                        y2={nameDirection === 'upward' ? -23 - 25 - 6 : 20}
+                        stroke="black"
+                    />
+                ) : (
+                    <line x1={0} x2={nameDirection === 'left' ? -60 : 60} y1={0} y2={0} stroke="black" />
+                )}
+
+                {effectiveIntBoxDir === 'left' || effectiveIntBoxDir === 'right' ? (
+                    <g
+                        transform={`translate(${effectiveIntBoxDir === 'left' ? nameSize.x - 10 : nameSize.x + nameSize.width + 10},${intBoxDYCompensation})`}
+                    >
+                        <IntBoxGroup2024
+                            groups={groups}
+                            dy={intBoxGroup2024DY[effectiveIntBoxDir]}
+                            align={effectiveIntBoxDir === 'left' ? 'end' : 'start'}
+                        />
+                    </g>
+                ) : (
+                    <IntBoxGroup2024 groups={groups} dy={effectiveIntBoxDY} />
+                )}
+
+                <StationName ref={nameRef} stnName={name} nameDirection={nameDirection} fill="black" />
+            </g>
+        );
+    }
 
     return (
         <g transform={`translate(0,${dy})`}>
             {nameDirection === 'upward' || nameDirection === 'downward' ? (
                 <>
-                    {info_panel_type !== PanelTypeShmetro.sh2024 && (
-                        <line
-                            x1={-nameSize.width / 2}
-                            x2={nameSize.width / 2}
-                            y1={verticalLineY[panel_type][nameDirection]}
-                            y2={verticalLineY[panel_type][nameDirection]}
-                            stroke="black"
-                        />
-                    )}
+                    <line
+                        x1={-nameSize.width / 2}
+                        x2={nameSize.width / 2}
+                        y1={verticalLineY[panel_type][nameDirection]}
+                        y2={verticalLineY[panel_type][nameDirection]}
+                        stroke="black"
+                    />
                     <line
                         y1={verticalLineY[panel_type][nameDirection]}
-                        y2={
-                            // TODO: this is too ugly
-                            nameDirection === 'upward'
-                                ? -23 - 25 - (info_panel_type === PanelTypeShmetro.sh2024 ? 6 : 0)
-                                : 20
-                        }
+                        y2={nameDirection === 'upward' ? -23 - 25 : 20}
                         stroke="black"
                     />
                 </>
             ) : (
                 <>
-                    {info_panel_type !== PanelTypeShmetro.sh2024 ? (
-                        <>
-                            <line
-                                x1={nameDirection === 'left' ? -50 : 15}
-                                x2={nameDirection === 'left' ? -15 : 50}
-                                y1={0}
-                                y2={0}
-                                stroke="black"
-                            />
-                            <line
-                                x1={nameDirection === 'left' ? -50 : 50}
-                                x2={nameDirection === 'left' ? -50 : 50}
-                                y1={-30}
-                                y2={30}
-                                stroke="black"
-                            />
-                        </>
-                    ) : (
-                        /* sh2024: horizontal lead going outward from station icon to name position */
-                        <line x1={0} x2={nameDirection === 'left' ? -60 : 60} y1={0} y2={0} stroke="black" />
-                    )}
+                    <line
+                        x1={nameDirection === 'left' ? -50 : 15}
+                        x2={nameDirection === 'left' ? -15 : 50}
+                        y1={0}
+                        y2={0}
+                        stroke="black"
+                    />
+                    <line
+                        x1={nameDirection === 'left' ? -50 : 50}
+                        x2={nameDirection === 'left' ? -50 : 50}
+                        y1={-30}
+                        y2={30}
+                        stroke="black"
+                    />
                 </>
             )}
 
-            {info_panel_type !== PanelTypeShmetro.sh2024 ? (
-                [...(groups[0].lines || []), ...(groups[1]?.lines || [])].length && (
-                    <IntBoxGroup
-                        intInfos={[groups[0].lines || [], groups[1]?.lines || []]}
-                        arrowDirection={nameDirection}
-                        services={services}
-                    />
-                )
-            ) : effectiveIntBoxDir === 'left' || effectiveIntBoxDir === 'right' ? (
-                // For side stations, place int boxes on the effectiveIntBoxDir side.
-                <g
-                    transform={`translate(${
-                        effectiveIntBoxDir === 'left' ? nameSize.x - 10 : nameSize.x + nameSize.width + 10
-                    },${intBoxDYCompensation})`}
-                >
-                    <IntBoxGroup2024
-                        groups={groups}
-                        dy={intBoxGroup2024DY[effectiveIntBoxDir]}
-                        align={effectiveIntBoxDir === 'left' ? 'end' : 'start'}
-                    />
-                </g>
-            ) : (
-                <IntBoxGroup2024 groups={groups} dy={effectiveIntBoxDY} />
+            {[...(groups[0].lines || []), ...(groups[1]?.lines || [])].length && (
+                <IntBoxGroup
+                    intInfos={[groups[0].lines || [], groups[1]?.lines || []]}
+                    arrowDirection={nameDirection}
+                    services={services}
+                />
             )}
 
             <StationName ref={nameRef} stnName={name} nameDirection={nameDirection} fill="black" />
 
-            {info_panel_type !== PanelTypeShmetro.sh2024 && groups[2]?.lines?.length && (
+            {groups[2]?.lines?.length && (
                 <g transform={`translate(${osysi_dx},${osysi_dy})`}>
                     <OSysIText osysiInfos={groups[2].lines} nameDirection={nameDirection} />
                 </g>
@@ -499,9 +507,9 @@ const IntBoxGroup2024 = forwardRef(function IntBoxGroup2024(
     const directionPolarity = 1;
 
     const transfer = [groups.at(0)?.lines ?? [], groups.at(1)?.lines ?? [], groups.at(2)?.lines ?? []];
+    const outOfStationTransfer = [...transfer[1], ...transfer[2]];
 
-    const [outOfSystemLine, setOutOfSystemLine] = useState(0); // also for start point of 出站换乘 (groups[1])
-    const [outOfSystemLine2, setOutOfSystemLine2] = useState(0); // for start point of 出站换乘 (groups[2])
+    const [outOfSystemLine, setOutOfSystemLine] = useState(0); // also for start point of 出站换乘
     const [intBoxesDX, setIntBoxesDX] = useState<{ [k in string]: number }>({});
     const textLineRefs = useRef<{ [k in string]: SVGGElement }>({});
     const [intBoxGroupWidth, setIntBoxGroupWidth] = useState(0);
@@ -535,7 +543,7 @@ const IntBoxGroup2024 = forwardRef(function IntBoxGroup2024(
             dx += getBBoxWidth(info);
         });
         let outOfStationLine = 0;
-        if (transfer[1].length) {
+        if (outOfStationTransfer.length) {
             // there will be a line and a text element for 出站换乘
             // each will take 22px
             const elementWidth = INT_BOX_SIZE.height;
@@ -548,34 +556,17 @@ const IntBoxGroup2024 = forwardRef(function IntBoxGroup2024(
                 outOfStationLine = 0;
                 dx += elementWidth;
             }
-            transfer[1].forEach(info => {
-                dx += getBBoxWidth(info);
-            });
-        }
-        let outOfSystemLine2 = 0;
-        if (transfer[2].length) {
-            const elementWidth = INT_BOX_SIZE.height;
-            const hasPrevious = transfer[0].length > 0 || transfer[1].length > 0;
-            if (hasPrevious) {
-                outOfSystemLine2 = dx + INT_BOX_SIZE.padding;
-                dx += elementWidth + 2 * INT_BOX_SIZE.padding;
-            } else {
-                dx += INT_BOX_SIZE.padding;
-                outOfSystemLine2 = 0;
-                dx += elementWidth;
-            }
-            transfer[2].forEach(info => {
+            outOfStationTransfer.forEach(info => {
                 dx += getBBoxWidth(info);
             });
         }
         setIntBoxesDX(intBoxDX);
         setOutOfSystemLine(outOfStationLine);
-        setOutOfSystemLine2(outOfSystemLine2);
         setIntBoxGroupWidth(dx);
-    }, [JSON.stringify(transfer)]);
+    }, [JSON.stringify(transfer), JSON.stringify(outOfStationTransfer)]);
 
     // only in case of one non out-of-station text line transfer, the text will be centered
-    const nonOutOfStationTransfer = [groups.at(0)?.lines ?? [], groups.at(2)?.lines ?? []];
+    const nonOutOfStationTransfer = [groups.at(0)?.lines ?? []];
     const onlyOneNonOutOfStationTextInt =
         transfer.flat().length === 1 &&
         nonOutOfStationTransfer.flat().length === 1 &&
@@ -601,18 +592,16 @@ const IntBoxGroup2024 = forwardRef(function IntBoxGroup2024(
         );
     };
 
-    const dx =
-        align === 'end'
-            ? -intBoxGroupWidth // right-align: all boxes end at the origin (outer side for left stations)
-            : align === 'start'
-              ? 0 // left-align: all boxes start at the origin (outer side for right stations)
-              : onlyOneNonOutOfStationTextInt
-                ? 0
-                : -intBoxGroupWidth / 2; // center (default)
+    const dx = (() => {
+        if (align === 'end') return -intBoxGroupWidth;
+        if (align === 'start') return 0;
+        if (onlyOneNonOutOfStationTextInt) return 0;
+        return -intBoxGroupWidth / 2;
+    })();
     return (
         <g ref={ref} fontSize={30} textAnchor="middle" transform={`translate(${dx},${dy})`}>
             {transfer[0].map(makeBoxElement)}
-            {transfer[1].length && (
+            {outOfStationTransfer.length > 0 && (
                 <>
                     {transfer[0].length > 0 && (
                         <line
@@ -633,31 +622,7 @@ const IntBoxGroup2024 = forwardRef(function IntBoxGroup2024(
                         <text dy="-4">出站</text>
                         <text dy="11">换乘</text>
                     </g>
-                    {transfer[1].map(makeBoxElement)}
-                </>
-            )}
-            {transfer[2].length > 0 && (
-                <>
-                    {(transfer[0].length > 0 || transfer[1].length > 0) && (
-                        <line
-                            y1={-INT_BOX_SIZE.height}
-                            y2={0}
-                            x1={outOfSystemLine2 - 2}
-                            x2={outOfSystemLine2 - 2}
-                            stroke="var(--rmg-black)"
-                        />
-                    )}
-                    <g
-                        transform={`translate(${outOfSystemLine2},-13.5)`}
-                        fill="var(--rmg-black)"
-                        fontSize="15"
-                        textAnchor="start"
-                        className="rmg-name__zh"
-                    >
-                        <text dy="-4">出站</text>
-                        <text dy="11">换乘</text>
-                    </g>
-                    {transfer[2].map(makeBoxElement)}
+                    {outOfStationTransfer.map(makeBoxElement)}
                 </>
             )}
         </g>

--- a/src/svgs/shmetro/loop/loop-shmetro.tsx
+++ b/src/svgs/shmetro/loop/loop-shmetro.tsx
@@ -142,11 +142,13 @@ const LoopSHMetro = (props: { bank_angle: boolean; canvas: CanvasType.RailMap | 
 
     // FIXME: branches with only one station could not display properly
     const dy = loop_branches.length ? 0 : ((line_ys[1] - line_ys[0]) * bank) / 2;
+    // sh2024 with coline needs stations rendered AFTER the coline track for correct z-order
+    const sh2024WithColine = info_panel_type === 'sh2024' && Object.keys(coline).length > 0;
     return (
         <g id="loop" transform={`translate(${dy},0)`}>
             <path stroke="var(--rmg-theme-colour)" strokeWidth={12} fill="none" d={path} strokeLinejoin="round" />
-            {/* Order matters. The LoopColine should cover the station in RailMap. */}
-            {canvas === CanvasType.RailMap && (
+            {/* For non-sh2024-coline: render stations before coline (existing z-order) */}
+            {canvas === CanvasType.RailMap && !sh2024WithColine && (
                 <LoopStationGroup canvas={canvas} loop_stns={loop_stns} xs={xs} ys={ys} />
             )}
             <g transform={`translate(0,${Object.keys(coline).length > 0 ? -LINE_WIDTH - COLINE_GAP : 0})`}>
@@ -167,6 +169,10 @@ const LoopSHMetro = (props: { bank_angle: boolean; canvas: CanvasType.RailMap | 
                     />
                 )}
             </g>
+            {/* For sh2024-coline: render stations AFTER coline so icons/names appear on top of coline line */}
+            {canvas === CanvasType.RailMap && sh2024WithColine && (
+                <LoopStationGroup canvas={canvas} loop_stns={loop_stns} xs={xs} ys={ys} />
+            )}
             {/* Order matters. The station should cover LoopColine's main path in Indoor. */}
             {canvas === CanvasType.Indoor && <LoopStationGroup canvas={canvas} loop_stns={loop_stns} xs={xs} ys={ys} />}
         </g>
@@ -245,7 +251,23 @@ const LoopStationGroup = (props: {
     };
 }) => {
     const { canvas, loop_stns, xs, ys } = props;
-    const { current_stn_idx: current_stn_id, stn_list } = useRootSelector(store => store.param);
+    const {
+        current_stn_idx: current_stn_id,
+        stn_list,
+        info_panel_type,
+        coline,
+    } = useRootSelector(store => store.param);
+
+    // In sh2024 indoor loop without coline, shift station icons inward by 6px
+    // so they appear to "penetrate" through the loop line.
+    const shouldShiftInward =
+        canvas === CanvasType.Indoor && info_panel_type === 'sh2024' && Object.keys(coline).length === 0;
+    const inwardOffset: Record<keyof LoopStns, { dx: number; dy: number }> = {
+        top: { dx: 0, dy: 6 },
+        bottom: { dx: 0, dy: 6 },
+        left: { dx: 6, dy: 0 },
+        right: { dx: -6, dy: 0 },
+    };
 
     const railmap_bank: Record<keyof LoopStns, -1 | 0 | 1> = {
         top: 0,
@@ -261,8 +283,8 @@ const LoopStationGroup = (props: {
     };
     const indoor_name_direction = (side: keyof LoopStns, i: number) =>
         ({
-            top: i % 2 === 0 ? 'upward' : 'downward',
-            bottom: i % 2 === 0 ? 'upward' : 'downward',
+            top: shouldShiftInward ? 'downward' : i % 2 === 0 ? 'upward' : 'downward',
+            bottom: shouldShiftInward ? 'upward' : i % 2 === 0 ? 'upward' : 'downward',
             left: 'left',
             right: 'right',
         })[side] as NameDirection;
@@ -279,6 +301,7 @@ const LoopStationGroup = (props: {
                                     stnState={current_stn_id === stn_id ? 0 : 1}
                                     bank={railmap_bank[side as keyof LoopStns]}
                                     direction={railmap_direction[side as keyof LoopStns]}
+                                    colineAbove={side === 'top'}
                                 />
                             </g>
                         ))
@@ -287,15 +310,22 @@ const LoopStationGroup = (props: {
                 Object.entries(loop_stns).map(([side, stn_ids]) =>
                     stn_ids
                         .filter(stn_id => stn_list[stn_id].services.length)
-                        .map((stn_id, i) => (
-                            <g key={stn_id} transform={`translate(${xs[stn_id]},${ys[stn_id]})`}>
-                                <StationSHMetroIndoor
-                                    stnId={stn_id}
-                                    nameDirection={indoor_name_direction(side as keyof LoopStns, i)}
-                                    services={[Services.local]}
-                                />
-                            </g>
-                        ))
+                        .map((stn_id, i) => {
+                            const offset = shouldShiftInward ? inwardOffset[side as keyof LoopStns] : { dx: 0, dy: 0 };
+                            return (
+                                <g
+                                    key={stn_id}
+                                    transform={`translate(${xs[stn_id] + offset.dx},${ys[stn_id] + offset.dy})`}
+                                >
+                                    <StationSHMetroIndoor
+                                        stnId={stn_id}
+                                        nameDirection={indoor_name_direction(side as keyof LoopStns, i)}
+                                        services={[Services.local]}
+                                        colineAbove={side === 'top'}
+                                    />
+                                </g>
+                            );
+                        })
                 )}
         </g>
     );

--- a/src/svgs/shmetro/loop/loop-shmetro.tsx
+++ b/src/svgs/shmetro/loop/loop-shmetro.tsx
@@ -288,6 +288,13 @@ const LoopStationGroup = (props: {
             left: 'left',
             right: 'right',
         })[side] as NameDirection;
+    // Int boxes on the inner side of the loop.
+    const indoor_intbox_direction: Record<keyof LoopStns, NameDirection> = {
+        top: 'upward',
+        bottom: 'downward',
+        left: 'right',
+        right: 'left',
+    };
     return (
         <g id="loop_stations">
             {canvas === CanvasType.RailMap &&
@@ -301,7 +308,6 @@ const LoopStationGroup = (props: {
                                     stnState={current_stn_id === stn_id ? 0 : 1}
                                     bank={railmap_bank[side as keyof LoopStns]}
                                     direction={railmap_direction[side as keyof LoopStns]}
-                                    colineAbove={side === 'top'}
                                 />
                             </g>
                         ))
@@ -321,7 +327,11 @@ const LoopStationGroup = (props: {
                                         stnId={stn_id}
                                         nameDirection={indoor_name_direction(side as keyof LoopStns, i)}
                                         services={[Services.local]}
-                                        colineAbove={side === 'top'}
+                                        intBoxDirection={
+                                            shouldShiftInward
+                                                ? indoor_intbox_direction[side as keyof LoopStns]
+                                                : undefined
+                                        }
                                     />
                                 </g>
                             );

--- a/src/svgs/shmetro/loop/loop-shmetro.tsx
+++ b/src/svgs/shmetro/loop/loop-shmetro.tsx
@@ -147,7 +147,7 @@ const LoopSHMetro = (props: { bank_angle: boolean; canvas: CanvasType.RailMap | 
     return (
         <g id="loop" transform={`translate(${dy},0)`}>
             <path stroke="var(--rmg-theme-colour)" strokeWidth={12} fill="none" d={path} strokeLinejoin="round" />
-            {/* For non-sh2024-coline: render stations before coline (existing z-order) */}
+            {/* For non-sh2024-coline: The LoopColine should cover the station in RailMap. */}
             {canvas === CanvasType.RailMap && !sh2024WithColine && (
                 <LoopStationGroup canvas={canvas} loop_stns={loop_stns} xs={xs} ys={ys} />
             )}
@@ -260,7 +260,7 @@ const LoopStationGroup = (props: {
 
     // In sh2024 indoor loop without coline, shift station icons inward by 6px
     // so they appear to "penetrate" through the loop line.
-    const shouldShiftInward =
+    const isSh2024IndoorLoop =
         canvas === CanvasType.Indoor && info_panel_type === 'sh2024' && Object.keys(coline).length === 0;
     const inwardOffset: Record<keyof LoopStns, { dx: number; dy: number }> = {
         top: { dx: 0, dy: 6 },
@@ -281,19 +281,17 @@ const LoopStationGroup = (props: {
         top: undefined,
         bottom: undefined,
     };
-    const indoor_name_direction = (side: keyof LoopStns, i: number) =>
-        ({
-            top: shouldShiftInward ? 'downward' : i % 2 === 0 ? 'upward' : 'downward',
-            bottom: shouldShiftInward ? 'upward' : i % 2 === 0 ? 'upward' : 'downward',
-            left: 'left',
-            right: 'right',
-        })[side] as NameDirection;
-    // Int boxes on the inner side of the loop.
-    const indoor_intbox_direction: Record<keyof LoopStns, NameDirection> = {
-        top: 'upward',
-        bottom: 'downward',
-        left: 'right',
-        right: 'left',
+    const indoor_name_direction = (side: keyof LoopStns, i: number): NameDirection => {
+        switch (side) {
+            case 'top':
+                return isSh2024IndoorLoop ? 'downward' : i % 2 === 0 ? 'upward' : 'downward';
+            case 'bottom':
+                return isSh2024IndoorLoop ? 'upward' : i % 2 === 0 ? 'upward' : 'downward';
+            case 'left':
+                return 'left';
+            case 'right':
+                return 'right';
+        }
     };
     return (
         <g id="loop_stations">
@@ -317,7 +315,7 @@ const LoopStationGroup = (props: {
                     stn_ids
                         .filter(stn_id => stn_list[stn_id].services.length)
                         .map((stn_id, i) => {
-                            const offset = shouldShiftInward ? inwardOffset[side as keyof LoopStns] : { dx: 0, dy: 0 };
+                            const offset = isSh2024IndoorLoop ? inwardOffset[side as keyof LoopStns] : { dx: 0, dy: 0 };
                             return (
                                 <g
                                     key={stn_id}
@@ -327,11 +325,7 @@ const LoopStationGroup = (props: {
                                         stnId={stn_id}
                                         nameDirection={indoor_name_direction(side as keyof LoopStns, i)}
                                         services={[Services.local]}
-                                        intBoxDirection={
-                                            shouldShiftInward
-                                                ? indoor_intbox_direction[side as keyof LoopStns]
-                                                : undefined
-                                        }
+                                        isSh2024IndoorLoop={isSh2024IndoorLoop}
                                     />
                                 </g>
                             );


### PR DESCRIPTION
## 描述
按照 https://github.com/railmapgen/rmg/issues/656 中所示，实现了非共线环线indoors线路图的“贯穿”效果，并把换乘标识移入环内。
如图（为了演示功能正常，虚构了一些内容）
<img width="5200" height="1350" alt="rmg y6id Tangqiao (6)" src="https://github.com/user-attachments/assets/9b242e51-6b10-4b27-b7fd-145dfc0640a7" />

## 其他说明
本功能代码主要由 Claude Sonnet 4.6/Opus 4.6 辅助生成。
经过人工审查与初步的测试，确认功能行为符合预期且与现有业务逻辑兼容。
