### PR TITLE
fix: clear ag-grid row selection when switching branch tabs

### DIFF
--- a/src/components/ag-grid/station-ag-grid.tsx
+++ b/src/components/ag-grid/station-ag-grid.tsx
@@ -42,6 +42,7 @@ export default function StationAgGrid(props: StationAgGridProps) {
     const dispatch = useRootDispatch();
 
     const sidePanelMode = useRootSelector(state => state.app.sidePanelMode);
+    const selectedBranch = useRootSelector(state => state.app.selectedBranch);
     const { style, theme, stn_list: stationList, line_num: lineNumber, coline } = useRootSelector(state => state.param);
     const branches = useRootSelector(state => state.helper.branches);
 
@@ -153,6 +154,13 @@ export default function StationAgGrid(props: StationAgGridProps) {
             }
         }
     }, [isGridReadyRef.current, sidePanelMode]);
+
+    useEffect(() => {
+        // clear row selection when switching branch tabs
+        if (isGridReadyRef.current && gridRef.current) {
+            gridRef.current.api.deselectAll();
+        }
+    }, [selectedBranch]);
 
     const [defaultColDef] = useState({
         resizable: true,


### PR DESCRIPTION
## 描述
原行为：切换选项卡时，至少一个行被选中，但是点击那个被选中的行不会改变侧边栏所编辑信息的站点。如果需要编辑那个不幸被选中的站点，那么需要先选另一行再重新选那一行。
现行为：切换选项卡时，清除选中任何行。

## 其他说明
本功能代码主要由 Claude Sonnet 4.6 辅助生成。
经过人工审查与初步的测试，确认功能行为符合预期且与现有业务逻辑兼容。